### PR TITLE
Add in ainsleyc DNS change and more misc project updating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - "0.6"
-  - "0.8"
   - "0.10"
+  - "0.12"
+  - "4"
 
 install:
   - npm install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,11 @@
+CHANGELOG
+=========
+
+## HEAD (Unreleased)
+* Thrown error when cacheDNS flag fails to resolve DNS name
+
+--------------------
+
+## 1.0.1 (2015-09-25)
+* Start from the base of https://github.com/sivy/node-statsd
+* Add the event API used by DogStatsD

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Datadog's [DogStatsD](http://docs.datadoghq.com/guides/dogstatsd/) server.
 
 This project is a fork off of [node-statsd](https://github.com/sivy/node-statsd)
 
+[![Build Status](https://secure.travis-ci.org/brightcove/hot-shots.png?branch=master)](http://travis-ci.org/brightcove/hot-shots)
+
 ## Installation
 
 ```
@@ -122,6 +124,15 @@ client.socket.on('error', function(error) {
 ```
 
 If you want to catch errors in sending a message then use the callback provided.
+
+## Submitting changes
+
+Thanks for considering making any updates to this project!  Here are the steps to take in your fork:
+
+1. Make sure you've added any new tests needed
+2. Run "npm install && npm unit"
+3. Update the HEAD section in CHANGES.md with a description of what you have done
+4. Push your changes and create the PR, and we'll try to get this merged in right away
 
 ## Name
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -41,8 +41,10 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
 
   if(options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
-      if(err == null){
+      if(err === null){
         self.host = address;
+      } else {
+        throw new Error(err);
       }
     });
   }
@@ -256,7 +258,7 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
     }
   }
   this.send(message, tags, callback);
-}
+};
 
 /**
  * Send a stat or event across the wire
@@ -294,7 +296,7 @@ Client.prototype.send = function (message, tags, callback) {
  */
 Client.prototype.close = function(){
     this.socket.close();
-}
+};
 
 exports = module.exports = Client;
 exports.StatsD = Client;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "Russ Bradberry <rbradberry@gmail.com>",
     "Brian Deitte <bdeitte@gmail.com>"
   ],
+  "keywords": [
+    "statsd",
+    "dogstatsd",
+    "datadog",
+    "metrics"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/brightcove/hot-shots.git"
@@ -21,11 +27,15 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "mocha -R spec",
+    "lint": "jshint lib/**.js test/**.js",
+    "pretest": "npm run lint"
   },
   "dependencies": {},
   "devDependencies": {
-    "mocha": "*"
+    "jshint": "2.x",
+    "mocha": "2.x"
+
   },
   "license": "MIT"
 }


### PR DESCRIPTION
@ainsleyc I brought in your change here from node-statsd, as I wanted to get in the PRs there in a versioned project (including my own change, which is why this new project got started).  I had to reapply the change here instead of just grabbing the fork, presumably because I didn't set up this project as a fork.

@csimi I would have also brought in your PR waiting in node-statsd, but it read me like this just affected a few versions of 0.12.x, and I wasn't sure where "_bindState" was really available, so I left it out.

@doron2402 I would have also brought in your PR waiting in node-statsd, but I didn't think that getting rid of allowing all the extra parameters on Client can be done without breaking users of the library.  (That would break how I use it at least.)