### PR TITLE
Adding support for Telegraf line protocol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ CHANGELOG
 
 --------------------
 
+## 2.1.0 (2015-12-9)
+* Add options.telegraf to enable support for Telegraf's StatsD line protocol format
+
 ## 2.0.0 (2015-10-22)
 * Add options.maxBufferSize and optinons.bufferFlushInterval
 * Change options.global_tags to options.globalTags for conistency

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # hot-shots
 
-A Node.js client for [Etsy](http://etsy.com)'s [StatsD](https://github.com/etsy/statsd) server and
-Datadog's [DogStatsD](http://docs.datadoghq.com/guides/dogstatsd/) server.
+A Node.js client for [Etsy](http://etsy.com)'s [StatsD](https://github.com/etsy/statsd) server that supports both Datadog's [DogStatsD](http://docs.datadoghq.com/guides/dogstatsd/) and [InfluxDB's](http://influxdb.com) [Telegraf](https://github.com/influxdb/telegraf) StatsD server.
 
 This project is a fork off of [node-statsd](https://github.com/sivy/node-statsd)
 
@@ -28,6 +27,7 @@ Parameters (specified as an options hash):
 * `globalTags`:  Tags that will be added to every metric `default: []`
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0`
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
+* `telegraf`:    Use Telegraf's StatsD line protocol `default: false`
 
 All StatsD methods other than event have the same API:
 * `name`:       Stat name `required`
@@ -75,7 +75,7 @@ The event method has the following API:
   client.set('my_unique', 'foobar');
   client.unique('my_unique', 'foobarbaz');
 
-  // Event: sends the titled event
+  // Event: sends the titled event (DataDog only)
   client.event('my_title', 'description');
 
   // Incrementing multiple items
@@ -147,4 +147,3 @@ Why is this project named hot-shots?  Because:
 ## License
 
 hot-shots is licensed under the MIT license.
-

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -16,7 +16,7 @@ var dgram = require('dgram'),
  *   @bufferFlushInterval {Number} the time out value to flush out buffer if not
  * @constructor
  */
-var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, globalTags, maxBufferSize, bufferFlushInterval) {
+var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, globalTags, maxBufferSize, bufferFlushInterval, telegraf) {
   var options = host || {},
          self = this;
 
@@ -29,9 +29,10 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       globalize   : globalize,
       cacheDns    : cacheDns,
       mock        : mock === true,
-      globalTags : globalTags,
+      globalTags  : globalTags,
       maxBufferSize : maxBufferSize,
-      bufferFlushInterval: bufferFlushInterval
+      bufferFlushInterval: bufferFlushInterval,
+      telegraf    : telegraf,
     };
   }
 
@@ -41,7 +42,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.suffix      = options.suffix || '';
   this.socket      = dgram.createSocket('udp4');
   this.mock        = options.mock;
-  this.globalTags = options.globalTags || [];
+  this.globalTags  = options.globalTags || [];
+  this.telegraf    = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
   this.buffer = "";
@@ -154,6 +156,10 @@ Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.event = function(title, text, options, tags, callback) {
+  if (this.telegraf) {
+    throw new Error('Not supported by Telegraf / InfluxDB');
+  }
+
   var message,
       msgTitle = title ? title : '',
       msgText = text ? text : title;
@@ -266,7 +272,7 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
       message += '|@' + sampleRate;
     } else {
       //don't want to send if we don't meet the sample ratio
-      return;
+      return callback();
     }
   }
   this.send(message, tags, callback);
@@ -289,7 +295,12 @@ Client.prototype.send = function (message, tags, callback) {
     mergedTags = mergedTags.concat(this.globalTags);
   }
   if(mergedTags.length > 0){
-    message += '|#' + mergedTags.join(',');
+    if (this.telegraf) {
+      message = message.split(':');
+      message = message[0] + ',' + mergedTags.join(',').replace(':', '=') + ':' + message.slice(1).join(':');
+    } else {
+      message += '|#' + mergedTags.join(',');
+    }
   }
 
   // Only send this stat if we're not a mock Client.
@@ -360,4 +371,3 @@ Client.prototype.close = function(){
 
 exports = module.exports = Client;
 exports.StatsD = Client;
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hot-shots",
   "description": "Node.js client for statsd and DogStatsD",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Steve Ivy",
   "contributors": [
     "Russ Bradberry <rbradberry@gmail.com>",


### PR DESCRIPTION
This PR adds support for InfluxDB's Telegraf [line protocol](https://github.com/influxdb/telegraf/tree/master/plugins/statsd). The primary difference is in how tags are sent, as well as InfluxDB does not have support for events.

I took the liberty of bumping the version (assuming semver) and updating the changelog. Let me know if you would rather I pull these out for you to update.