### PR TITLE
Fix an increment and close bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ none
 
 --------------------
 
+## 2.3.0 (2015-1-17)
+* @bdeitte Fix increment(name, 0) to send a 0 count instead of 1
+* @bdeitte Flush the queue when needed on close()
+
 ## 2.2.0 (2015-1-10)
 * @bdeitte Document and expand on close API
 * @bdeitte Catch more error cases for callbacks

--- a/README.md
+++ b/README.md
@@ -149,10 +149,13 @@ client.socket.on('error', function(error) {
 
 Thanks for considering making any updates to this project!  Here are the steps to take in your fork:
 
-1. Make sure you've added any new tests needed
-2. Run "npm install && npm test"
-3. Update the HEAD section in CHANGES.md with a description of what you have done
-4. Push your changes and create the PR, and we'll try to get this merged in right away
+1. Run "npm install"
+2. Add your changes in your fork as well as any new tests needed
+3. Run "npm test"
+4. Update the HEAD section in CHANGES.md with a description of what you have done
+5. Push your changes and create the PR
+
+When you've done all this we're happy to try to get this merged in right away.
 
 ## Name
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -88,7 +88,7 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
-  // we explitcly check for undefined and null (and don't do a "! value" check)
+  // we explicitly check for undefined and null (and don't do a "! value" check)
   // so that 0 values are allowed and sent through as-is
   if (value === undefined || value === null) {
     value = 1;

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -88,7 +88,12 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value || 1, 'c', sampleRate, tags, callback);
+  // we explitcly check for undefined and null (and don't do a "! value" check)
+  // so that 0 values are allowed and sent through as-is
+  if (value === undefined || value === null) {
+    value = 1;
+  }
+  this.sendAll(stat, value, 'c', sampleRate, tags, callback);
 };
 
 /**
@@ -374,6 +379,10 @@ Client.prototype.onBufferFlushInterval = function() {
 Client.prototype.close = function(callback){
   if(this.intervalHandle) {
     clearInterval(this.intervalHandle);
+  }
+
+  if(this.buffer.length >= 0) {
+    this.flushQueue();
   }
 
   if (callback) {

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -504,6 +504,19 @@ describe('StatsD', function(){
       });
     });
 
+    it('should use when increment is 0', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:0|c');
+        server.close();
+        finished();
+      }, function(server){
+        var address = server.address(),
+            statsd = new StatsD(address.address, address.port);
+
+        statsd.increment('test', 0);
+      });
+    });
+
     it('should send proper count format with tags', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:42|c|#foo,bar');


### PR DESCRIPTION
Fix increment(name, 0) to send a 0 count instead of 1, as mentioned in https://github.com/sivy/node-statsd/issues/41
Flush the queue when needed on close()
