### PR TITLE
Bug Fix: Should not send messages larger then maxBufferSize

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -328,10 +328,13 @@ Client.prototype.send = function (message, tags, callback) {
  * @param message {String} The constructed message without tags
  */
 Client.prototype.enqueue = function(message){
-  this.buffer += message + "\n";
-  if(this.buffer.length >= this.maxBufferSize) {
+  message += "\n";
+
+  if (this.buffer.length + message.length > this.maxBufferSize) {
     this.flushQueue();
   }
+
+  this.buffer += message;
 };
 
 /**

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -848,10 +848,27 @@ describe('StatsD', function(){
         var options = {
           host: address.host,
           port: address.port,
+          maxBufferSize: 12
+        };
+        var statsd = new StatsD(options);
+        statsd.increment('a', 1);
+        statsd.increment('b', 2);
+      });
+    });
+
+    it('should not send batches larger then maxBufferSize', function (finished) {
+      udpTest(function (message, server) {
+        assert.equal(message, 'a:1|c\n');
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address();
+        var options = {
+          host: address.host,
+          port: address.port,
           maxBufferSize: 8
         };
         var statsd = new StatsD(options);
-
         statsd.increment('a', 1);
         statsd.increment('b', 2);
       });


### PR DESCRIPTION
Currently the queue is flushed when the buffer size is larger then `maxBufferSize`. However, this results in emitting messages larger then maximum size. As max size should be more or less equal to the network MTU, this results in package truncation in the network. So, instead we need to flush the queue when we discover that adding one more message to the buffer will result in exceeding the max buffer size.
