### PR TITLE
Switch to sending the DNS cache error in the send callback when possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ none
 
 --------------------
 
+## 2.4.0 (2015-2-26)
+* @arlolra Shrink npm package
+* @arlolra/@bdeitte Move DNS errors when caching them to send() and use callback when possible
+* @bdeitte Use callback for Telegraf error when possible
+
 ## 2.3.1 (2015-2-3)
 * @Pchelolo Ensure messages not larger then maxBufferSize
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Some of the functionality mentioned above is specific to DogStatsD or Telegraf. 
 
 As usual, callbacks will have an error as their first parameter.  You can have an error in both the message and close callbacks.
 
+If the optional callback is not given, an error is thrown in some cases and a console.log message is used in others.  An error will only be thrown when there is a missing callback if it is some potential configuration issue to be fixed.
+
 In the event that there is a socket error, `hot-shots` will allow this error to bubble up.  If you would like to catch the errors, just attach a listener to the socket property on the instance.
 
 ```javascript

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -57,7 +57,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
       if(err === null){
         self.host = address;
       } else {
-        throw new Error(err);
+	self.dnsError = err;
       }
     });
   }
@@ -65,23 +65,6 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   if(options.globalize){
     global.statsd = this;
   }
-};
-
-/**
- * Callback with a constructed client,
- * returning an error for a dns cache failure.
- */
-Client.create = function(options, cb) {
-  options = options || {};
-  if(!options.cacheDns) {
-    return cb(null, new Client(options));
-  }
-  options.cacheDns = false;  // Don't do this in the constructor.
-  dns.lookup(options.host || 'localhost', function(err, address){
-    if (err) { return cb(err); }
-    options.host = address;
-    cb(null, new Client(options));
-  });
 };
 
 /**
@@ -179,7 +162,11 @@ Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
  */
 Client.prototype.event = function(title, text, options, tags, callback) {
   if (this.telegraf) {
-    throw new Error('Not supported by Telegraf / InfluxDB');
+    var err = new Error('Not supported by Telegraf / InfluxDB');
+    if (callback) {
+      return callback(err);
+    }
+    throw err;
   }
 
   var message,
@@ -306,8 +293,16 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.send = function (message, tags, callback) {
-  var mergedTags = [];
+  // we may have a cached error rather than a cached lookup, so
+  // throw it on
+  if (this.dnsError) {
+    if (callback) {
+      return callback(this.dnsError);
+    }
+    throw this.dnsError;
+  }
 
+  var mergedTags = [];
   if(tags && Array.isArray(tags)){
     mergedTags = mergedTags.concat(tags);
   }


### PR DESCRIPTION
Also:
- update the tests for this case
- use the callback if possible for a Telegraf error
- CHANGES/README updates for all this

See https://github.com/brightcove/hot-shots/pull/16 as well