### PR TITLE
Child client

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ test
 perfTest
 *~
 .idea/
+.npmignore
+.travis.yml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-none
+* @ash2k Method to create child clients
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ The event method has the following API:
   client.histogram('my_histogram', 42, ['tag'], next);
   client.histogram('my_histogram', 42, 0.25, ['tag'], next);
 
+  // Use a child client to add more context to the client.
+  // Clients can be nested.
+  var childClient = client.childClient({
+    prefix: 'additionalPrefix.',
+    suffix: '.additionalSuffix',
+    globalTags: ['globalTag1:forAllMetricsFromChildClient']
+  });
+  childClient.increment('my_counter_with_more_tags');
+
   // Close statsd.  This will ensure all stats are sent and stop statsd
   // from doing anything more.
   client.close(function(err) {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -49,13 +49,15 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
   this.bufferHolder = options.isChild ? options.bufferHolder : { buffer: "" };
 
+  // We only want a single flush event per parent and all its child clients
   if(!options.isChild && this.maxBufferSize > 0) {
     this.intervalHandle = setInterval(this.onBufferFlushInterval.bind(this), this.bufferFlushInterval);
   }
 
   if (options.isChild) {
-    this.cacheDns = options.cacheDns;
-    this.dnsError = options.dnsError;
+    if (options.dnsError) {
+      this.dnsError = options.dnsError;
+    }
   } else if (options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
       if(err === null){
@@ -425,7 +427,7 @@ Client.prototype.close = function(callback){
 };
 
 /**
- * Creates a child client that adds prefix, suffix and/or tags to this client
+ * Creates a child client that adds prefix, suffix and/or tags to this client. Child client can itself have children.
  * @param options
  *   @option prefix      {String}  An optional prefix to assign to each stat name sent
  *   @option suffix      {String}  An optional suffix to assign to each stat name sent
@@ -438,18 +440,19 @@ Client.prototype.childClient = function(options) {
 var ChildClient = function (parent, options) {
   options = options || {};
   Client.call(this, {
-    // share socket and buffer (via intermediate object)
     isChild     : true,
-    socket      : parent.socket,
+    socket      : parent.socket, // Child inherits socket from parent. Parent itself can be a child.
+    // All children and parent share the same buffer via sharing an object (cannot mutate strings)
     bufferHolder: parent.bufferHolder,
+    dnsError    : parent.dnsError, // Child inherits an error from parent (if it is there)
 
     host        : parent.host,
     port        : parent.port,
-    prefix      : (options.prefix || '') + parent.prefix,
-    suffix      : parent.suffix + (options.suffix || ''),
-    globalize   : false,
-    cacheDns    : parent.cacheDns,
+    prefix      : (options.prefix || '') + parent.prefix, // Child has its prefix prepended to parent's prefix
+    suffix      : parent.suffix + (options.suffix || ''), // Child has its suffix appended to parent's suffix
+    globalize   : false, // Only "root" client can be global
     mock        : parent.mock,
+    // Append child's tags to parent's tags
     globalTags  : Array.isArray(options.globalTags) ? parent.globalTags.concat(options.globalTags) : parent.globalTags,
     maxBufferSize : parent.maxBufferSize,
     bufferFlushInterval: parent.bufferFlushInterval,

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,4 +1,5 @@
 var dgram = require('dgram'),
+    util = require('util'),
     dns   = require('dns');
 
 /**
@@ -40,24 +41,27 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock, gl
   this.port        = options.port || 8125;
   this.prefix      = options.prefix || '';
   this.suffix      = options.suffix || '';
-  this.socket      = dgram.createSocket('udp4');
+  this.socket      = options.isChild ? options.socket : dgram.createSocket('udp4');
   this.mock        = options.mock;
-  this.globalTags  = options.globalTags || [];
+  this.globalTags  = Array.isArray(options.globalTags) ? options.globalTags : [];
   this.telegraf    = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
-  this.buffer = "";
+  this.bufferHolder = options.isChild ? options.bufferHolder : { buffer: "" };
 
-  if(this.maxBufferSize > 0) {
+  if(!options.isChild && this.maxBufferSize > 0) {
     this.intervalHandle = setInterval(this.onBufferFlushInterval.bind(this), this.bufferFlushInterval);
   }
 
-  if(options.cacheDns === true){
+  if (options.isChild) {
+    this.cacheDns = options.cacheDns;
+    this.dnsError = options.dnsError;
+  } else if (options.cacheDns === true){
     dns.lookup(options.host, function(err, address, family){
       if(err === null){
         self.host = address;
       } else {
-	self.dnsError = err;
+        self.dnsError = err;
       }
     });
   }
@@ -342,19 +346,19 @@ Client.prototype.send = function (message, tags, callback) {
 Client.prototype.enqueue = function(message){
   message += "\n";
 
-  if (this.buffer.length + message.length > this.maxBufferSize) {
+  if (this.bufferHolder.buffer.length + message.length > this.maxBufferSize) {
     this.flushQueue();
   }
 
-  this.buffer += message;
+  this.bufferHolder.buffer += message;
 };
 
 /**
  * Flush the buffer, sending on the messages
  */
 Client.prototype.flushQueue = function(){
-  this.sendMessage(this.buffer);
-  this.buffer = "";
+  this.sendMessage(this.bufferHolder.buffer);
+  this.bufferHolder.buffer = "";
 };
 
 /**
@@ -383,7 +387,7 @@ Client.prototype.sendMessage = function(message, callback){
  * Called every bufferFlushInterval to flush any buffer that is around
  */
 Client.prototype.onBufferFlushInterval = function() {
-  if(this.buffer !== "") {
+  if(this.bufferHolder.buffer !== "") {
     this.flushQueue();
   }
 };
@@ -396,7 +400,7 @@ Client.prototype.close = function(callback){
     clearInterval(this.intervalHandle);
   }
 
-  if(this.buffer.length >= 0) {
+  if(this.bufferHolder.buffer.length >= 0) {
     this.flushQueue();
   }
 
@@ -419,6 +423,40 @@ Client.prototype.close = function(callback){
     }
   }
 };
+
+/**
+ * Creates a child client that adds prefix, suffix and/or tags to this client
+ * @param options
+ *   @option prefix      {String}  An optional prefix to assign to each stat name sent
+ *   @option suffix      {String}  An optional suffix to assign to each stat name sent
+ *   @option globalTags {Array=} Optional tags that will be added to every metric
+ */
+Client.prototype.childClient = function(options) {
+  return new ChildClient(this, options);
+};
+
+var ChildClient = function (parent, options) {
+  options = options || {};
+  Client.call(this, {
+    // share socket and buffer (via intermediate object)
+    isChild     : true,
+    socket      : parent.socket,
+    bufferHolder: parent.bufferHolder,
+
+    host        : parent.host,
+    port        : parent.port,
+    prefix      : (options.prefix || '') + parent.prefix,
+    suffix      : parent.suffix + (options.suffix || ''),
+    globalize   : false,
+    cacheDns    : parent.cacheDns,
+    mock        : parent.mock,
+    globalTags  : Array.isArray(options.globalTags) ? parent.globalTags.concat(options.globalTags) : parent.globalTags,
+    maxBufferSize : parent.maxBufferSize,
+    bufferFlushInterval: parent.bufferFlushInterval,
+    telegraf    : parent.telegraf
+  });
+};
+util.inherits(ChildClient, Client);
 
 exports = module.exports = Client;
 exports.StatsD = Client;

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -237,6 +237,16 @@ describe('StatsD child client', doTests.bind(null, function () {
     // empty options to verify same behaviour
   });
 }));
+describe('StatsD child of a child client', doTests.bind(null, function () {
+  var statsd = new (
+      Function.prototype.bind.apply(mainStatsD, [null].concat(Array.prototype.slice.call(arguments, 0)))
+  )();
+  return statsd.childClient({
+    // empty options to verify same behaviour
+  }).childClient({
+    // empty options to verify same behaviour
+  });
+}));
 
 function doTests(StatsD){
 

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -1,6 +1,6 @@
 var dgram = require('dgram'),
     assert = require('assert'),
-    StatsD = require('../').StatsD;
+    mainStatsD = require('../').StatsD;
 
 /**
  * Creates a test harness, that binds to an ephemeral port
@@ -22,69 +22,20 @@ function udpTest(test, callback){
 }
 
 /**
- * Given a StatsD method, make sure no data is sent to the server
- * for this method when used on a mock Client.
- */
-function assertMockClientMethod(method, finished){
- var testFinished = "test finished message";
-
-  udpTest(function(message, server){
-    // We only expect to get our own test finished message, no stats.
-    assert.equal(message, testFinished);
-    server.close();
-    finished();
-  }, function(server){
-    var address = server.address(),
-        statsd = new StatsD(address.address, address.port, 'prefix', 'suffix', false, false,
-                            /* mock = true */ true),
-        socket = dgram.createSocket("udp4"),
-        buf = new Buffer(testFinished),
-        callbackThrows = false;
-
-    // Regression test for "undefined is not a function" with missing callback on mock instance.
-    try {
-      statsd[method]('test', 1);
-    } catch(e) {
-      callbackThrows = true;
-    }
-    assert.ok(!callbackThrows);
-
-    statsd[method]('test', 1, null, function(error, bytes){
-      assert.ok(!error);
-      assert.equal(bytes, 0);
-      // We should call finished() here, but we have to work around
-      // https://github.com/joyent/node/issues/2867 on node 0.6,
-      // such that we don't close the socket within the `listening` event
-      // and pass a single message through instead.
-      socket.send(buf, 0, buf.length, address.port, address.address,
-                  function(){ socket.close(); });
-    });
-  });
-}
-
-/**
  * Since sampling uses random, we need to patch Math.random() to always give
- * a consisten result
+ * a consistent result
  */
 Math.random = function(){
   return 0.42;
 };
 
+beforeEach(function () {
+  //remove it from the namespace to not fail other tests
+  delete global.statsd;
+});
 
-describe('StatsD', function(){
-  describe('#init', function(){
-    it('should set default values when not specified', function(){
-      // cachedDns isn't tested here; see below
-      var statsd = new StatsD();
-      assert.equal(statsd.host, 'localhost');
-      assert.equal(statsd.port, 8125);
-      assert.equal(statsd.prefix, '');
-      assert.equal(statsd.suffix, '');
-      assert.equal(global.statsd, undefined);
-      assert.equal(statsd.mock, undefined);
-      assert.deepEqual(statsd.globalTags, []);
-      assert.ok(!statsd.mock);
-    });
+describe('StatsD (main client only)', function (StatsD) {
+  describe('#init', function() {
 
     it('should set the proper values when specified', function(){
       // cachedDns isn't tested here; see below
@@ -144,16 +95,205 @@ describe('StatsD', function(){
 
       // replace the dns lookup function with our mock dns lookup
       dns.lookup = function(host, callback){
-	return callback(new Error('that is a bad host'));
+        return callback(new Error('that is a bad host'));
       };
 
       statsd = new StatsD({host: 'localhost', cacheDns: true});
 
       statsd.increment('test', 1, 1, null, function(err) {
-	assert.equal(err.message, 'that is a bad host');
+        assert.equal(err.message, 'that is a bad host');
         dns.lookup = originalLookup;
         done();
       });
+    });
+
+    it('should create a global variable set to StatsD() when specified', function(){
+      var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true);
+      assert.ok(global.statsd instanceof StatsD);
+    });
+
+  });
+
+  describe('#buffer', function() {
+    it('should aggregate packets when maxBufferSize is set to non-zero', function (finished) {
+      udpTest(function (message, server) {
+        assert.equal(message, 'a:1|c\nb:2|c\n');
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address();
+        var options = {
+          host: address.host,
+          port: address.port,
+          maxBufferSize: 12
+        };
+        var statsd = new StatsD(options);
+        statsd.increment('a', 1);
+        statsd.increment('b', 2);
+      });
+    });
+  });
+
+}.bind(null, mainStatsD));
+
+describe('StatsD (child client only)', function (StatsD) {
+  describe('#init', function() {
+
+    it('should set the proper values when specified', function(){
+      var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true, null, true, ['gtag']);
+      var child = statsd.childClient({
+            prefix: 'preff.',
+            suffix: '.suff',
+            globalTags: ['awesomeness:over9000']
+          });
+      assert.equal(child.prefix, 'preff.prefix');
+      assert.equal(child.suffix, 'suffix.suff');
+      assert.equal(statsd, global.statsd);
+      assert.deepEqual(child.globalTags, ['gtag', 'awesomeness:over9000']);
+    });
+
+  });
+
+  describe('#buffer', function() {
+    it('should aggregate packets when maxBufferSize is set to non-zero', function (finished) {
+      udpTest(function (message, server) {
+        assert.equal(message, 'a:1|c\nb:2|c\n');
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address();
+        var options = {
+          host: address.host,
+          port: address.port,
+          maxBufferSize: 12
+        };
+        var statsd = new StatsD(options).childClient();
+        statsd.increment('a', 1);
+        statsd.increment('b', 2);
+      });
+    });
+  });
+
+  describe('#childClient', function() {
+
+    it('should add tags, prefix and suffix without parent values', function (finished) {
+      udpTest(function (message, server) {
+        assert.equal(message, 'preff.a.suff:1|c|#awesomeness:over9000\npreff.b.suff:2|c|#awesomeness:over9000\n');
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address();
+        var options = {
+          host: address.host,
+          port: address.port,
+          maxBufferSize: 500
+        };
+        var statsd = new StatsD(options).childClient({
+          prefix: 'preff.',
+          suffix: '.suff',
+          globalTags: ['awesomeness:over9000']
+        });
+        statsd.increment('a', 1);
+        statsd.increment('b', 2);
+      });
+    });
+
+    it('should add tags, prefix and suffix with parent values', function (finished) {
+      udpTest(function (message, server) {
+        assert.equal(message, 'preff.p.a.s.suff:1|c|#xyz,awesomeness:over9000\npreff.p.b.s.suff:2|c|#xyz,awesomeness:over9000\n');
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address();
+        var options = {
+          host: address.host,
+          port: address.port,
+          prefix: 'p.',
+          suffix: '.s',
+          globalTags: ['xyz'],
+          maxBufferSize: 500
+        };
+        var statsd = new StatsD(options).childClient({
+          prefix: 'preff.',
+          suffix: '.suff',
+          globalTags: ['awesomeness:over9000']
+        });
+        statsd.increment('a', 1);
+        statsd.increment('b', 2);
+      });
+    });
+
+  });
+
+}.bind(null, mainStatsD));
+
+describe('StatsD main client', doTests.bind(null, mainStatsD));
+describe('StatsD child client', doTests.bind(null, function () {
+  // https://stackoverflow.com/questions/1606797/use-of-apply-with-new-operator-is-this-possible
+  var statsd = new (
+      Function.prototype.bind.apply(mainStatsD, [null].concat(Array.prototype.slice.call(arguments, 0)))
+  )();
+  return statsd.childClient({
+    // empty options to verify same behaviour
+  });
+}));
+
+function doTests(StatsD){
+
+  /**
+   * Given a StatsD method, make sure no data is sent to the server
+   * for this method when used on a mock Client.
+   */
+  function assertMockClientMethod(method, finished){
+    var testFinished = "test finished message";
+
+    udpTest(function(message, server){
+      // We only expect to get our own test finished message, no stats.
+      assert.equal(message, testFinished);
+      server.close();
+      finished();
+    }, function(server){
+      var address = server.address(),
+          statsd = new StatsD(address.address, address.port, 'prefix', 'suffix', false, false,
+              /* mock = true */ true),
+          socket = dgram.createSocket("udp4"),
+          buf = new Buffer(testFinished),
+          callbackThrows = false;
+
+      // Regression test for "undefined is not a function" with missing callback on mock instance.
+      try {
+        statsd[method]('test', 1);
+      } catch(e) {
+        callbackThrows = true;
+      }
+      assert.ok(!callbackThrows);
+
+      statsd[method]('test', 1, null, function(error, bytes){
+        assert.ok(!error);
+        assert.equal(bytes, 0);
+        // We should call finished() here, but we have to work around
+        // https://github.com/joyent/node/issues/2867 on node 0.6,
+        // such that we don't close the socket within the `listening` event
+        // and pass a single message through instead.
+        socket.send(buf, 0, buf.length, address.port, address.address,
+            function(){ socket.close(); });
+      });
+    });
+  }
+
+  describe('#init', function(){
+
+    it('should set default values when not specified', function(){
+      // cachedDns isn't tested here; see below
+      var statsd = new StatsD();
+      assert.equal(statsd.host, 'localhost');
+      assert.equal(statsd.port, 8125);
+      assert.equal(statsd.prefix, '');
+      assert.equal(statsd.suffix, '');
+      assert.equal(global.statsd, undefined);
+      assert.equal(statsd.mock, undefined);
+      assert.deepEqual(statsd.globalTags, []);
+      assert.ok(!statsd.mock);
     });
 
     it('should not attempt to cache a dns record if dnsCache is not specified', function(done){
@@ -172,13 +312,6 @@ describe('StatsD', function(){
         dns.lookup = originalLookup;
         done();
       });
-    });
-
-    it('should create a global variable set to StatsD() when specified', function(){
-      var statsd = new StatsD('host', 1234, 'prefix', 'suffix', true);
-      assert.ok(global.statsd instanceof StatsD);
-      //remove it from the namespace to not fail other tests
-      delete global.statsd;
     });
 
     it('should not create a global variable when not specified', function(){
@@ -994,4 +1127,4 @@ describe('StatsD', function(){
     });
 
   });
-});
+}


### PR DESCRIPTION
A child client can be used e.g. in a middleware - it can be passed to the request handlers, enriched with additional tags. WDYT?

Inspired by https://github.com/msiebuhr/node-statsd-client/blob/master/lib/statsd-client.js#L40