### PR TITLE
Error handler

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[**]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[**.{json,js,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,8 @@ test
 perfTest
 *~
 .idea/
+.editorconfig
+.gitignore
+.jshintrc
 .npmignore
 .travis.yml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* @ash2k Support a client-wide error handler used in case no callback provided and to handle various exceptions.
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Parameters (specified as an options hash):
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0`
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`
+* `errorHandler`: A function with one argument. It is called to handle various errors. `default: none`, errors are thrown/logger to console
 
 All StatsD methods other than event and close have the same API:
 * `name`:       Stat name `required`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -15,6 +15,7 @@ var dgram = require('dgram'),
  *   @option cacheDns    {boolean} An optional option to only lookup the hostname -> ip address once
  *   @option mock        {boolean} An optional boolean indicating this Client is a mock object, no stats are sent.
  *   @option globalTags {Array=} Optional tags that will be added to every metric
+ *   @option errorHandler {Function=} Optional function to handle errors when callback is not provided
  *   @maxBufferSize      {Number} An optional value for aggregating metrics to send, mainly for performance improvement
  *   @bufferFlushInterval {Number} the time out value to flush out buffer if not
  * @constructor
@@ -51,6 +52,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.maxBufferSize = options.maxBufferSize || 0;
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
   this.bufferHolder = options.isChild ? options.bufferHolder : { buffer: "" };
+  this.errorHandler = options.errorHandler;
 
   // We only want a single flush event per parent and all its child clients
   if(!options.isChild && this.maxBufferSize > 0) {
@@ -175,6 +177,10 @@ Client.prototype.event = function(title, text, options, tags, callback) {
     if (callback) {
       return callback(err);
     }
+    else if (this.errorHandler) {
+      return this.errorHandler(err);
+    }
+
     throw err;
   }
 
@@ -248,17 +254,24 @@ Client.prototype.sendAll = function(stat, value, type, sampleRate, tags, callbac
    */
   function onSend(error, bytes){
     completed += 1;
-    if(calledback || typeof callback !== 'function'){
+    if(calledback){
       return;
     }
 
     if(error){
-      calledback = true;
-      return callback(error);
+      if (typeof callback === 'function') {
+        calledback = true;
+        callback(error);
+      }
+      else if (self.errorHandler) {
+        calledback = true;
+        self.errorHandler(error);
+      }
+      return;
     }
 
     sentBytes += bytes;
-    if(completed === stat.length){
+    if(completed === stat.length && typeof callback === 'function'){
       callback(null, sentBytes);
     }
   }
@@ -289,7 +302,7 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
       message += '|@' + sampleRate;
     } else {
       //don't want to send if we don't meet the sample ratio
-      return callback();
+      return callback ? callback() : undefined;
     }
   }
   this.send(message, tags, callback);
@@ -299,7 +312,7 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
  * Send a stat or event across the wire
  * @param message {String} The constructed message without tags
  * @param tags {Array} The tags to include (along with global tags). Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
+ * @param callback {Function=} Callback when message is done being delivered (only if maxBufferSize == 0). Optional.
  */
 Client.prototype.send = function (message, tags, callback) {
   // we may have a cached error rather than a cached lookup, so
@@ -307,6 +320,9 @@ Client.prototype.send = function (message, tags, callback) {
   if (this.dnsError) {
     if (callback) {
       return callback(this.dnsError);
+    }
+    else if (this.errorHandler) {
+      return this.errorHandler(this.dnsError);
     }
     throw this.dnsError;
   }
@@ -382,6 +398,9 @@ Client.prototype.sendMessage = function(message, callback){
     if (callback) {
       callback(new Error(errMessage));
     }
+    else if (this.errorHandler) {
+      this.errorHandler(new Error(errMessage));
+    }
     else {
       console.log(errMessage);
     }
@@ -423,6 +442,9 @@ Client.prototype.close = function(callback){
     if (callback) {
       callback(new Error(errMessage));
     }
+    else if (this.errorHandler) {
+      this.errorHandler(new Error(errMessage));
+    }
     else {
       console.log(errMessage);
     }
@@ -437,6 +459,7 @@ var ChildClient = function (parent, options) {
     // All children and parent share the same buffer via sharing an object (cannot mutate strings)
     bufferHolder: parent.bufferHolder,
     dnsError    : parent.dnsError, // Child inherits an error from parent (if it is there)
+    errorHandler: options.errorHandler || parent.errorHandler, // Handler for callback errors
 
     host        : parent.host,
     port        : parent.port,

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -389,6 +389,14 @@ Client.prototype.flushQueue = function(){
  * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
 Client.prototype.sendMessage = function(message, callback){
+  // Guard against "RangeError: Offset into buffer too large" in node 0.10
+  // https://github.com/nodejs/node-v0.x-archive/issues/7884
+  if (message === "") {
+    if (callback) {
+      callback(null);
+    }
+    return;
+  }
   var buf = new Buffer(message);
   try {
     this.socket.send(buf, 0, buf.length, this.port, this.host, callback);
@@ -411,9 +419,7 @@ Client.prototype.sendMessage = function(message, callback){
  * Called every bufferFlushInterval to flush any buffer that is around
  */
 Client.prototype.onBufferFlushInterval = function() {
-  if(this.bufferHolder.buffer !== "") {
-    this.flushQueue();
-  }
+  this.flushQueue();
 };
 
 /**
@@ -424,9 +430,7 @@ Client.prototype.close = function(callback){
     clearInterval(this.intervalHandle);
   }
 
-  if(this.bufferHolder.buffer.length >= 0) {
-    this.flushQueue();
-  }
+  this.flushQueue();
 
   if (callback) {
     // use the close event rather than adding a callback to close()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Steve Ivy",
   "contributors": [
     "Russ Bradberry <rbradberry@gmail.com>",
-    "Brian Deitte <bdeitte@gmail.com>"
+    "Brian Deitte <bdeitte@gmail.com>",
+    "Mikhail Mazurskiy <mikhail.mazursky@gmail.com>"
   ],
   "keywords": [
     "statsd",

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -556,6 +556,39 @@ function doTests(StatsD) {
     it('should send no histogram stat when a mock Client is used', function(finished){
       assertMockClientMethod('histogram', finished);
     });
+
+    it('should call callback after histogram call', function(finished){
+      udpTest(function(message, server){
+        assert.equal(message, 'test:42|h');
+        server.close();
+      }, function(server){
+        var address = server.address(),
+          statsd = new StatsD(address.address, address.port);
+
+        statsd.histogram('test', 42, null, null, function(err, data) {
+          assert.equal(data, 9);
+          finished();
+        });
+      });
+    });
+
+    it('should have error in callback after bad histogram call', function(finished){
+      udpTest(function(message, server){
+        throw new Error('should not be called');
+      }, function(server){
+        var address = server.address(),
+          statsd = new StatsD(address.address, address.port);
+
+        statsd.close(function() {
+          statsd.histogram('test', 42, null, null, function(err, data) {
+            assert.ok(err !== undefined);
+            assert.ok(data === undefined);
+            finished();
+          });
+        });
+      });
+    });
+
   });
 
   describe('#gauge', function(finished){
@@ -978,6 +1011,16 @@ function doTests(StatsD) {
       });
     });
 
+    it('should use errorHandler', function (finished) {
+      var statsd = new StatsD({
+        telegraf: true,
+        errorHandler: function () {
+          finished();
+        }
+      });
+      statsd.event('test title', 'another desc');
+    });
+
   });
 
   describe('#buffer', function() {
@@ -1071,21 +1114,7 @@ function doTests(StatsD) {
     });
   });
 
-  describe('#callbacks', function(finished){
-    it('should call callback after histogram call', function(finished){
-      udpTest(function(message, server){
-        assert.equal(message, 'test:42|h');
-        server.close();
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.histogram('test', 42, null, null, function(err, data) {
-          assert.equal(data, 9);
-          finished();
-        });
-      });
-    });
+  describe('#close', function(){
 
     it('should call callback after close call', function(finished){
       udpTest(function(message, server){
@@ -1100,21 +1129,66 @@ function doTests(StatsD) {
       });
     });
 
-    it('should have error in callback after bad histogram call', function(finished){
-      udpTest(function(message, server){
-        throw new Error('should not be called');
-      }, function(server){
-        var address = server.address(),
-            statsd = new StatsD(address.address, address.port);
-
-        statsd.close(function() {
-          statsd.histogram('test', 42, null, null, function(err, data) {
-            assert.ok(err !== undefined);
-            assert.ok(data === undefined);
-            finished();
-          });
-        });
+    it('should use errorHandler', function (finished) {
+      var statsd = new StatsD({
+        errorHandler: function (e) {
+          finished();
+        }
       });
+      statsd.socket.close = function () {
+        throw new Error('boom!');
+      };
+      statsd.close();
+    });
+
+  });
+
+  describe('#send', function() {
+
+    it('should use errorHandler', function (finished) {
+      var err = new Error('boom!');
+      var statsd = new StatsD({
+        errorHandler: function (e) {
+          assert.equal(e, err);
+          finished();
+        }
+      });
+      statsd.dnsError = err;
+      statsd.send('test title');
+    });
+
+  });
+
+  describe('#sendMessage', function() {
+
+    it('should use errorHandler', function (finished) {
+      var err = new Error('boom!');
+      var statsd = new StatsD({
+        errorHandler: function (e) {
+          assert.equal(e, err);
+          finished();
+        }
+      });
+      statsd.dnsError = err;
+      statsd.send('test title');
+    });
+
+  });
+
+  describe('#sendAll', function() {
+
+    it('should use errorHandler', function (finished) {
+      var err = new Error('boom!');
+      var statsd = new StatsD({
+        errorHandler: function (e) {
+          assert.equal(e, err);
+          finished();
+        }
+      });
+      statsd.sendStat = function (item, value, type, sampleRate, tags, callback) {
+        callback(err);
+      };
+      statsd.sendAll(['test title'], 'another desc');
     });
 
   });

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -408,7 +408,7 @@ function doTests(StatsD) {
 
   });
 
-  describe('#timing', function(finished){
+  describe('#timing', function(){
     it('should send proper time format without prefix, suffix, sampling and callback', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:42|ms');
@@ -483,7 +483,7 @@ function doTests(StatsD) {
     });
   });
 
-  describe('#histogram', function(finished){
+  describe('#histogram', function(){
     it('should send proper histogram format without prefix, suffix, sampling and callback', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:42|h');
@@ -591,7 +591,7 @@ function doTests(StatsD) {
 
   });
 
-  describe('#gauge', function(finished){
+  describe('#gauge', function(){
     it('should send proper gauge format without prefix, suffix, sampling and callback', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:42|g');
@@ -666,7 +666,7 @@ function doTests(StatsD) {
     });
   });
 
-  describe('#increment', function(finished){
+  describe('#increment', function(){
     it('should send count by 1 when no params are specified', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:1|c');
@@ -754,7 +754,7 @@ function doTests(StatsD) {
     });
   });
 
-  describe('#decrement', function(finished){
+  describe('#decrement', function(){
     it('should send count by -1 when no params are specified', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:-1|c');
@@ -830,7 +830,7 @@ function doTests(StatsD) {
     });
   });
 
-  describe('#set', function(finished){
+  describe('#set', function(){
     it('should send proper set format without prefix, suffix, sampling and callback', function(finished){
       udpTest(function(message, server){
         assert.equal(message, 'test:42|s');
@@ -904,7 +904,7 @@ function doTests(StatsD) {
       assertMockClientMethod('set', finished);
     });
   });
-  describe('#event', function(finished) {
+  describe('#event', function() {
     it('should send proper event format for title and text', function (finished) {
       udpTest(function (message, server) {
         assert.equal(message, '_e{4,11}:test|description');


### PR DESCRIPTION
Libraries should not assume that they could write to `console`. This PR provides a way to override default behaviour and also provide a handler for errors when `callback` was not passed. Also some minor cleanups.