### PR TITLE
Support multiline text in DataDog events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* @ash2k Support multiline text in DataDog events
 
 --------------------
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -184,9 +184,12 @@ Client.prototype.event = function(title, text, options, tags, callback) {
     throw err;
   }
 
+  // Convert to strings
   var message,
-      msgTitle = title ? title : '',
-      msgText = text ? text : title;
+      msgTitle = String(title ? title : ''),
+      msgText = String(text ? text : msgTitle);
+  // Escape new lines (unescaping is supported by DataDog)
+  msgText = msgText.replace(/\n/g, '\\n');
 
   // start out the message with the event-specific title and text info
   message = '_e{' + msgTitle.length + ',' + msgText.length + '}:' + msgTitle + '|' + msgText;

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -951,7 +951,7 @@ function doTests(StatsD) {
     it('should send proper event format for title, text, and options', function (finished) {
       var date = new Date();
       udpTest(function (message, server) {
-        assert.equal(message, '_e{10,12}:test title|another desc|d:' + date.getTime() +
+        assert.equal(message, '_e{10,31}:test title|another\\nmultiline\\ndescription|d:' + date.getTime() +
             '|h:host|k:ag_key|p:low|s:source_type|t:warning');
         server.close();
         finished();
@@ -967,7 +967,7 @@ function doTests(StatsD) {
               alert_type: 'warning'
             };
 
-        statsd.event('test title', 'another desc', options);
+        statsd.event('test title', 'another\nmultiline\ndescription', options);
       });
     });
 


### PR DESCRIPTION
See description of text here http://docs.datadoghq.com/guides/dogstatsd/
`_unescape_event_text()` in https://github.com/DataDog/dd-agent/blob/master/aggregator.py#L504