### PR TITLE
Add support for DataDog Service Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The check method has the following API:
   // Event: sends the titled event (DataDog only)
   client.event('my_title', 'description');
 
+  // Check: sends a service check (DataDog only)
+  client.check('service.up', client.CHECKS.OK, { hostname: 'host-1' }, ['foo', 'bar'])
+
   // Incrementing multiple items
   client.increment(['these', 'are', 'different', 'stats']);
 
@@ -153,6 +156,7 @@ Some of the functionality mentioned above is specific to DogStatsD or Telegraf. 
 * telegraf parameter- Telegraf
 * histogram method- DogStatsD or Telegraf
 * event method- DogStatsD
+* check method- DogStatsD
 
 ## Errors
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ The event method has the following API:
 * `tags`:       The Array of tags to add to metrics `default: []`
 * `callback`:   The callback to execute once the metric has been sent.
 
+The check method has the following API:
+
+* `name`:        Check name `required`
+* `status`:      Check status `required`
+* `options`:     Options for the check
+  * `date_happened`    Assign a timestamp to the check `default is now`
+  * `hostname`         Assign a hostname to the check.
+  * `message`          Assign a message to the check.
+* `tags`:       The Array of tags to add to metrics `default: []`
+* `callback`:   The callback to execute once the metric has been sent.
+
 ```javascript
   var StatsD = require('hot-shots'),
       client = new StatsD();

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -76,6 +76,13 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   if(options.globalize){
     global.statsd = this;
   }
+
+  this.CHECKS = {
+    OK: 0,
+    WARNING: 1,
+    CRITICAL: 2,
+    UNKNOWN: 3,
+  };
 };
 
 /**
@@ -158,6 +165,68 @@ Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
 };
 
 /**
+ * Send a service check
+ * @param name {String} The name of the service check
+ * @param status {Number=} The status of the service check (0 to 3).
+ * @param options
+ *   @option date_happened {Date} Assign a timestamp to the event. Default is now.
+ *   @option hostname {String} Assign a hostname to the check.
+ *   @option message {String} Assign a message to the check.
+ * @param tags {Array=} The Array of tags to add to the check. Optional.
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
+ */
+Client.prototype.check = function(name, status, options, tags, callback) {
+  if (this.telegraf) {
+    var err = new Error('Not supported by Telegraf / InfluxDB');
+    if (callback) {
+      return callback(err);
+    }
+    else if (this.errorHandler) {
+      return this.errorHandler(err);
+    }
+
+    throw err;
+  }
+  var check = ['_sc', name, status],
+    metadata = options || {};
+
+  if (metadata.date_happened) {
+    var timestamp = formatDate(metadata.date_happened);
+    if (timestamp) {
+      check.push('d:' + timestamp);
+    }
+  }
+  if (metadata.hostname) {
+    check.push('h:' + metadata.hostname);
+  }
+
+  var mergedTags = this.globalTags;
+  if (tags && Array.isArray(tags)) {
+    mergedTags = overrideTags(mergedTags, tags);
+  }
+  if (mergedTags.length > 0) {
+    check.push('#' + mergedTags.join(','));
+  }
+
+  // message has to be the last part of a service check
+  if (metadata.message) {
+    check.push('m:' + metadata.message);
+  }
+
+  // allow for tags to be omitted and callback to be used in its place
+  if(typeof tags === 'function' && callback === undefined) {
+    callback = tags;
+  }
+
+  var message = check.join('|');
+  // Service checks are unique in that message has to be the last element in
+  // the stat if provided, so we can't append tags like other checks. This
+  // directly calls the `_send` method to avoid appending tags, since we've
+  // already added them.
+  this._send(message, callback);
+};
+
+/**
  * Send on an event
  * @param title {String} The title of the event
  * @param text {String} The description of the event.  Optional- title is used if not given.
@@ -196,12 +265,11 @@ Client.prototype.event = function(title, text, options, tags, callback) {
 
   // add in the event-specific options
   if (options) {
-    if (options.date_happened instanceof Date) {
-      // Datadog expects seconds.
-      message += '|d:' + Math.round(options.date_happened.getTime() / 1000);
-    } else if (options.date_happened instanceof Number) {
-      // Make sure it is an integer, not a float.
-      message += '|d:' + Math.round(options.date_happened);
+    if (options.date_happened) {
+      var timestamp = formatDate(options.date_happened);
+      if (timestamp) {
+        message += '|d:' + timestamp;
+      }
     }
     if (options.hostname) {
       message += '|h:' + options.hostname;
@@ -322,18 +390,6 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
  * @param callback {Function=} Callback when message is done being delivered (only if maxBufferSize == 0). Optional.
  */
 Client.prototype.send = function (message, tags, callback) {
-  // we may have a cached error rather than a cached lookup, so
-  // throw it on
-  if (this.dnsError) {
-    if (callback) {
-      return callback(this.dnsError);
-    }
-    else if (this.errorHandler) {
-      return this.errorHandler(this.dnsError);
-    }
-    throw this.dnsError;
-  }
-
   var mergedTags = this.globalTags;
   if(tags && Array.isArray(tags)){
     mergedTags = overrideTags(mergedTags, tags);
@@ -345,6 +401,26 @@ Client.prototype.send = function (message, tags, callback) {
     } else {
       message += '|#' + mergedTags.join(',');
     }
+  }
+  this._send(message, callback);
+};
+
+/**
+ * Send a stat or event across the wire
+ * @param message {String} The constructed message without tags
+ * @param callback {Function=} Callback when message is done being delivered (only if maxBufferSize == 0). Optional.
+ */
+Client.prototype._send = function (message, callback) {
+  // we may have a cached error rather than a cached lookup, so
+  // throw it on
+  if (this.dnsError) {
+    if (callback) {
+      return callback(this.dnsError);
+    }
+    else if (this.errorHandler) {
+      return this.errorHandler(this.dnsError);
+    }
+    throw this.dnsError;
   }
 
   // Only send this stat if we're not a mock Client.
@@ -528,6 +604,19 @@ function overrideTags (parent, child) {
     result.push(key + ':' + childCopy[key]);
   });
   return result.concat(toAppend);
+}
+
+// Formats a date for use with DataDog
+function formatDate(date) {
+  var timestamp;
+  if (date instanceof Date) {
+    // Datadog expects seconds.
+    timestamp = Math.round(date.getTime() / 1000);
+  } else if (date instanceof Number) {
+    // Make sure it is an integer, not a float.
+    timestamp = Math.round(date);
+  }
+  return timestamp;
 }
 
 exports = module.exports = Client;


### PR DESCRIPTION
http://docs.datadoghq.com/guides/dogstatsd/#service-checks

I based this off of the `event` api. The only major difference is that data dog requires `message` to be the last value for a service check, so I had to work around `send` appending tags.