### PR TITLE
Allow socket errors to be handled with errorHandler. Fixes #31.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,19 @@ As usual, callbacks will have an error as their first parameter.  You can have a
 
 If the optional callback is not given, an error is thrown in some cases and a console.log message is used in others.  An error will only be thrown when there is a missing callback if it is some potential configuration issue to be fixed.
 
-In the event that there is a socket error, `hot-shots` will allow this error to bubble up.  If you would like to catch the errors, just attach a listener to the socket property on the instance.
+In the event that there is a socket error, `hot-shots` will allow this error to bubble up unless a `errorHandler` is specified.  If you would like to catch the errors, either specify an `errorHandler` in your root client or just attach a listener to the socket property on the instance.
 
 ```javascript
+// Using errorHandler
+var client = new StatsD({
+  errorHandler: function (error) {
+    console.log("Socket errors caught here: ", error);
+  }
+})
+```
+
+```javascript
+// Attaching an error handler to client's socket
 client.socket.on('error', function(error) {
   console.error("Error in socket: ", error);
 });

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ As usual, callbacks will have an error as their first parameter.  You can have a
 
 If the optional callback is not given, an error is thrown in some cases and a console.log message is used in others.  An error will only be thrown when there is a missing callback if it is some potential configuration issue to be fixed.
 
-In the event that there is a socket error, `hot-shots` will allow this error to bubble up unless a `errorHandler` is specified.  If you would like to catch the errors, either specify an `errorHandler` in your root client or just attach a listener to the socket property on the instance.
+In the event that there is a socket error, `hot-shots` will allow this error to bubble up unless an `errorHandler` is specified.  If you would like to catch the errors, either specify an `errorHandler` in your root client or just attach a listener to the socket property on the instance.
 
 ```javascript
 // Using errorHandler

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -72,6 +72,10 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       }
     });
   }
+  
+  if (!options.isChild && options.errorHandler) {
+    this.socket.on('error', options.errorHandler);
+  }
 
   if(options.globalize){
     global.statsd = this;

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -1331,6 +1331,11 @@ function doTests(StatsD) {
       d.on('error', function (error) {
         assert.ok(error);
         assert.equal(error.code, 'ENOTFOUND');
+        
+        // Important to exit the domain or further tests will continue to run
+        // therein.
+        d.exit();
+        
         finished();
       });
     

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var dgram = require('dgram'),
+    domain = require('domain'),
     assert = require('assert'),
     mainStatsD = require('../').StatsD;
 
@@ -1292,6 +1293,50 @@ function doTests(StatsD) {
       });
       statsd.dnsError = err;
       statsd.send('test title');
+    });
+    
+    it('should errback for an unresolvable host', function (finished) {
+      var statsd = new StatsD({
+        host: 'unresolvable'
+      });
+    
+      statsd.send('test title', [], function (error) {
+        assert.ok(error);
+        assert.equal(error.code, 'ENOTFOUND');
+        finished();
+      });
+    });
+    
+    it('should use errorHandler for an unresolvable host', function (finished) {
+      var statsd = new StatsD({
+        host: 'unresolvable',
+        errorHandler: function (error) {
+          assert.ok(error);
+          assert.equal(error.code, 'ENOTFOUND');
+          finished();
+        }
+      });
+    
+      statsd.send('test title');
+    });
+    
+    it('should throw for an unresolvable host', function (finished) {
+      var d = domain.create();
+      var statsd = new StatsD({
+        host: 'unresolvable',
+      });
+      
+      d.add(statsd.socket);
+      
+      d.on('error', function (error) {
+        assert.ok(error);
+        assert.equal(error.code, 'ENOTFOUND');
+        finished();
+      });
+    
+      d.run(function () {
+        statsd.send('test title');
+      });
     });
 
   });


### PR DESCRIPTION
This PR:

- Uses the optional `errorHandler`, if present, as an `error` listener on the udp socket (**only on the parent**.
- Adds tests demonstrating scenarios that are and are not handled.

What is unclear:

- Should the `errorHandler` of child clients also be added as listeners? Thoughts?