### PR TITLE
Fix callback behavior when using maxBufferSize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+* @RandomSeeded Fix callbacks not being triggered when using buffers
 
 --------------------
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -433,7 +433,7 @@ Client.prototype._send = function (message, callback) {
       this.sendMessage(message, callback);
     }
     else {
-      this.enqueue(message);
+      this.enqueue(message, callback);
     }
   }
   else {
@@ -448,21 +448,26 @@ Client.prototype._send = function (message, callback) {
  *
  * @param message {String} The constructed message without tags
  */
-Client.prototype.enqueue = function(message){
+Client.prototype.enqueue = function(message, callback){
   message += "\n";
 
   if (this.bufferHolder.buffer.length + message.length > this.maxBufferSize) {
-    this.flushQueue();
+    this.flushQueue(callback);
+    this.bufferHolder.buffer += message;
   }
-
-  this.bufferHolder.buffer += message;
+  else {
+    this.bufferHolder.buffer += message;
+    if (callback) {
+      callback(null);
+    }
+  }
 };
 
 /**
  * Flush the buffer, sending on the messages
  */
-Client.prototype.flushQueue = function(){
-  this.sendMessage(this.bufferHolder.buffer);
+Client.prototype.flushQueue = function(callback){
+  this.sendMessage(this.bufferHolder.buffer, callback);
   this.bufferHolder.buffer = "";
 };
 


### PR DESCRIPTION
Prior to this PR, any callbacks provided to `_send` were ignored when using `maxBufferSize`, despite the following line in the documentation: `callback: The callback to execute once the metric has been sent or buffered`

This PR:
- passes the provided callback to `sendMessage` if `maxBuferSize` is exceeded
- Otherwise, invokes the provided callback after buffering the metric, which matches the documentation