### PR TITLE
Add backwards compatibility for global_tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ $ npm install hot-shots
 You generally just need to do two things:
 
 1. Change node-statsd to hot-shots in all requires
-2. Change global_stats to globalStats as a parameter name
 
 You may also want to use the Datadog events support in here instead of other libraries.  You can also check the detailed [change log](https://github.com/brightcove/hot-shots/blob/master/CHANGES.md) for what has changed since the last release of node-statsd.
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -43,6 +43,9 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
     };
   }
 
+  // hidden global_tags option for backwards compatibility
+  options.globalTags = options.globalTags || options.global_tags;
+
   this.host        = options.host || 'localhost';
   this.port        = options.port || 8125;
   this.prefix      = options.prefix || '';

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -74,6 +74,14 @@ describe('StatsD (main client only)', function (StatsD) {
       assert.deepEqual(statsd.globalTags, ['gtag']);
     });
 
+    it('should map global_tags to globalTags for backwards compatibility', function(){
+      // cachedDns isn't tested here; see below
+      var statsd = new StatsD({
+        global_tags: ['gtag']
+      });
+      assert.deepEqual(statsd.globalTags, ['gtag']);
+    });
+
     it('should attempt to cache a dns record if dnsCache is specified', function(done){
       var dns = require('dns'),
           originalLookup = dns.lookup,

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -75,7 +75,6 @@ describe('StatsD (main client only)', function (StatsD) {
     });
 
     it('should map global_tags to globalTags for backwards compatibility', function(){
-      // cachedDns isn't tested here; see below
       var statsd = new StatsD({
         global_tags: ['gtag']
       });


### PR DESCRIPTION
This fixes #28

I believe the readme referenced global_stats and globalStats in error, since I can't find either of those variables in the code. I think probably it should have said global_tags and globalTags, so I want ahead and took that line out.