### PR TITLE
Typescript types take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Node.js client for StatsD, DogStatsD, and Telegraf",
   "version": "4.8.0",
   "author": "Steve Ivy",
+  "types": "./types.d.ts",
   "contributors": [
     "Russ Bradberry <rbradberry@gmail.com>",
     "Brian Deitte <bdeitte@gmail.com>",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,74 @@
+declare module "hot-shots" {
+  export interface ClientOptions {
+    host?: string;
+    port?: number;
+    prefix?: string;
+    suffix?: string;
+    globalize?: boolean;
+    cacheDns?: boolean;
+    mock?: boolean;
+    globalTags?: string[];
+    maxBufferSize?: number;
+    bufferFlushInterval?: number;
+    telegraf?: boolean;
+    sampleRate?: number;
+    errorHandler?: (err: Error) => void;
+  }
+
+  export interface CheckOptions {
+    date_happened?: Date;
+    hostname?: string;
+    message?: string;
+  }
+
+  export interface DatadogChecks {
+    OK: 0;
+    WARNING: 1;
+    CRITICAL: 2;
+    UNKNOWN: 3;
+  }
+
+  type unionFromInterfaceValues4<
+    T,
+    K1 extends keyof T,
+    K2 extends keyof T,
+    K3 extends keyof T,
+    K4 extends keyof T,
+  > = T[K1] | T[K2] | T[K3] | T[K4];
+
+  export type DatadogChecksValues = unionFromInterfaceValues4<DatadogChecks, "OK", "WARNING", "CRITICAL", "UNKNOWN">;
+
+  export interface EventOptions {
+    aggregation_key?: string;
+    alert_type?: "info" | "warning" | "success" | "error";
+    date_happened?: Date;
+    hostname?: string;
+    priority?: "low" | "normal";
+    source_type_name?: string;
+  }
+
+  export type StatsCb = (error: Error | undefined, bytes: any) => void;
+  export type StatsCall = (stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb) => void;
+
+  export class StatsD {
+    constructor(options?: ClientOptions);
+    increment(stat: string): void;
+    increment(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+
+    decrement(stat: string): void;
+    decrement(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+
+    timing(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+    histogram(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+    gauge(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+    set(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+    unique(stat: string | string[], value: number, sampleRate?: number, tags?: string[], callback?: StatsCb): void;
+
+    close(callback: () => void): void;
+
+    event(title: string, text?: string, options?: EventOptions, tags?: string[], callback?: StatsCb): void;
+    check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: string[], callback?: StatsCb): void;
+
+    public CHECKS: DatadogChecks;
+  }
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -76,4 +76,6 @@ declare module "hot-shots" {
 
     public CHECKS: DatadogChecks;
   }
+
+  export default StatsD;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,18 +1,23 @@
+import dgram = require("dgram");
+
 declare module "hot-shots" {
   export interface ClientOptions {
+    bufferFlushInterval?: number;
+    bufferHolder?: { buffer: string };
+    cacheDns?: boolean;
+    errorHandler?: (err: Error) => void;
+    globalTags?: string[];
+    globalize?: boolean;
     host?: string;
+    isChild?: boolean;
+    maxBufferSize?: number;
+    mock?: boolean;
     port?: number;
     prefix?: string;
-    suffix?: string;
-    globalize?: boolean;
-    cacheDns?: boolean;
-    mock?: boolean;
-    globalTags?: string[];
-    maxBufferSize?: number;
-    bufferFlushInterval?: number;
-    telegraf?: boolean;
     sampleRate?: number;
-    errorHandler?: (err: Error) => void;
+    socket?: dgram.Socket;
+    suffix?: string;
+    telegraf?: boolean;
   }
 
   export interface CheckOptions {

--- a/types.d.ts
+++ b/types.d.ts
@@ -76,6 +76,7 @@ declare module "hot-shots" {
 
     public CHECKS: DatadogChecks;
   }
-
-  export default StatsD;
 }
+
+declare const StatsDClient: StatsD;
+export default StatsDClient;


### PR DESCRIPTION
> This change is not backwards compatible with Typescript projects that are already using statsd.
>
> require('hot-shots') does not resolve to StatsD
> the client (StatsD instance) is missing the socket method

I've added some missing options, but I'm unsure how to resolve the the default export issue. Whenever I try to do `export = StatsD` I get an error:

`error TS2309: An export assignment cannot be used in a module with other exported elements.`