### PR TITLE
Update typings to point to 'hot-shots/lib' 

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,6 @@
 import dgram = require("dgram");
 
-declare module "hot-shots" {
+declare module "hot-shots/lib" {
   export interface ClientOptions {
     bufferFlushInterval?: number;
     bufferHolder?: { buffer: string };


### PR DESCRIPTION
Because the actual module is in a lib directory it seems that you need to define the typescript module as "hot-shots/lib" for it to properly get picked up.