### PR TITLE
Add 'timer' decorator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ The check method has the following API:
   // Timer: Records how long a given function takes to execute (in milliseconds),
   // and then sends that value using 'client.timing'
   var fn = function(a, b) { return a + b };
-  var metricsArgs = { 'stat': 'response_time' };
-  client.timer(fn, metricsArgs)(2, 2);
+  client.timer(fn, 'fn_execution_time')(2, 2);
 
   // Increment: Increments a stat by a value (default is 1)
   client.increment('my_counter');

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ The check method has the following API:
   // Timing: sends a timing command with the specified milliseconds
   client.timing('response_time', 42);
 
+  // Timer: Records how long a given function takes to execute (in milliseconds),
+  // and then sends that value using 'client.timing'
+  var fn = function(a, b) { return a + b };
+  var metricsArgs = { 'stat': 'response_time' };
+  client.timer(fn, metricsArgs)(2, 2);
+
   // Increment: Increments a stat by a value (default is 1)
   client.increment('my_counter');
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -108,6 +108,34 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
 };
 
 /**
+ * Function that records the time to run a given function
+ * and sends the recorded time (in milliseconds)
+ * @param func {Function} The function to run
+ * @param metricsArgs {Object} The arguments to be used by Client.prototype.timing
+ */
+Client.prototype.timer = function (func, metricsArgs) {
+  var _this = this;
+
+  return function () {
+    var start = process.hrtime();
+    try {
+      return func(Array.from(arguments));
+    } finally {
+      // get duration in milliseconds
+      var duration = process.hrtime(start)[1] / 1000000;
+
+      _this.timing(
+        metricsArgs.stat,
+        duration,
+        metricsArgs.sampleRate,
+        metricsArgs.tags,
+        metricsArgs.callback
+      );
+    }
+  };
+};
+
+/**
  * Increments a stat by a specified amount
  * @param stat {String|Array} The stat(s) to send
  * @param value The value to send

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -108,12 +108,14 @@ Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
 };
 
 /**
- * Function that records the time to run a given function
- * and sends the recorded time (in milliseconds)
+ * Represents the timing stat by recording the duration a function takes to run (in milliseconds)
  * @param func {Function} The function to run
- * @param metricsArgs {Object} The arguments to be used by Client.prototype.timing
+ * @param stat {String|Array} The stat(s) to send
+ * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+ * @param tags {Array=} The Array of tags to add to metrics. Optional.
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
  */
-Client.prototype.timer = function (func, metricsArgs) {
+Client.prototype.timer = function (func, stat, sampleRate, tags, callback) {
   var _this = this;
 
   return function () {
@@ -125,11 +127,11 @@ Client.prototype.timer = function (func, metricsArgs) {
       var duration = process.hrtime(start)[1] / 1000000;
 
       _this.timing(
-        metricsArgs.stat,
+        stat,
         duration,
-        metricsArgs.sampleRate,
-        metricsArgs.tags,
-        metricsArgs.callback
+        sampleRate,
+        tags,
+        callback
       );
     }
   };

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -488,7 +488,7 @@ function doTests(StatsD) {
   });
 
   describe('#timer', function() {
-    it('should send data to timing function', function(finished) {
+    it('should send stat and time to execute to timing function', function(finished) {
       udpTest(function (message, server) {
         // Search for a string similar to 'test:0.123|ms'
         var re = RegExp("(test:)([0-9]+\.[0-9]+)\\|{1}(ms)");
@@ -505,6 +505,30 @@ function doTests(StatsD) {
 
         var metricsArgs = {
           stat: 'test'
+        };
+
+        statsd.timer(testFunc, metricsArgs)(2, 2);
+      });
+    });
+
+    it('should send data with tags to timing function', function(finished) {
+      udpTest(function (message, server) {
+        // Search for a string similar to 'test:0.123|ms|#foo,bar'
+        var re = RegExp("(test:)([0-9]+\.[0-9]+)\\|{1}(ms)\\|{1}\\#(foo,bar)");
+        assert.equal(true, re.test(message));
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address(),
+          statsd = new StatsD(address.address, address.port);
+
+        var testFunc = function (a, b) {
+          return a + b;
+        };
+
+        var metricsArgs = {
+          stat: 'test',
+          tags: ['foo', 'bar']
         };
 
         statsd.timer(testFunc, metricsArgs)(2, 2);

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -503,11 +503,7 @@ function doTests(StatsD) {
           return a + b;
         };
 
-        var metricsArgs = {
-          stat: 'test'
-        };
-
-        statsd.timer(testFunc, metricsArgs)(2, 2);
+        statsd.timer(testFunc, 'test')(2, 2);
       });
     });
 
@@ -526,12 +522,7 @@ function doTests(StatsD) {
           return a + b;
         };
 
-        var metricsArgs = {
-          stat: 'test',
-          tags: ['foo', 'bar']
-        };
-
-        statsd.timer(testFunc, metricsArgs)(2, 2);
+        statsd.timer(testFunc, 'test', undefined, ['foo', 'bar'])(2, 2);
       });
     });
   });

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -487,6 +487,31 @@ function doTests(StatsD) {
 
   });
 
+  describe('#timer', function() {
+    it('should send data to timing function', function(finished) {
+      udpTest(function (message, server) {
+        // Search for a string similar to 'test:0.123|ms'
+        var re = RegExp("(test:)([0-9]+\.[0-9]+)\\|{1}(ms)");
+        assert.equal(true, re.test(message));
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address(),
+          statsd = new StatsD(address.address, address.port);
+
+        var testFunc = function(a, b) {
+          return a + b;
+        };
+
+        var metricsArgs = {
+          stat: 'test'
+        };
+
+        statsd.timer(testFunc, metricsArgs)(2, 2);
+      });
+    });
+  });
+
   describe('#timing', function(){
     it('should send proper time format without prefix, suffix, sampling and callback', function(finished){
       udpTest(function(message, server){


### PR DESCRIPTION
Some of my co-workers and I have been finding it very useful to record how long a given function takes to execute, and then send that time on to our StatsD server using the `timing` function. We thought this might be a useful addition to the library.

Sample use of this function:

```
function add(a, b) {
  return a + b;
}

// Would send the time taken to execute 'add' as the 'time'
// argument to the 'timing' function
timer(add, 'add_execution_time')(2, 3);

```