### PR TITLE
encode routes as utf8 w/ readFileSync when using useDefaultRoute option

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -725,7 +725,7 @@ function intToIP(int) {
 // Returns the system default interface on Linux
 function getDefaultRoute() {
   try {
-    var fileContents = fs.readFileSync('/proc/net/route');
+    var fileContents = fs.readFileSync('/proc/net/route', 'utf8');
     var routes = fileContents.split('\n');
     for (var route in routes) {
       var fields = route.trim().split('');


### PR DESCRIPTION
`fs.readFileSync` [returns a buffer by default](https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options). This allows the `useDefaultRoute` option to work properly.

