### PR TITLE
Split up single file, add code coverage capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .idea/
 *.iml
+.nyc_output
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,5 @@ perfTest
 .jshintrc
 .npmignore
 .travis.yml
+.nyc_output
+coverage

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,104 @@
+"use strict";
+
+var fs = require('fs');
+
+function sanitizeTags(value, telegraf) {
+  var blacklist = telegraf ? /:|\|/g : /:|\||@|,/g;
+  // Replace reserved chars with underscores.
+  return (value + "").replace(blacklist, "_");
+}
+
+function formatTags(tags, telegraf) {
+  if (Array.isArray(tags)) {
+    return tags;
+
+  } else {
+    return Object.keys(tags).map(function (key) {
+      return sanitizeTags(key, telegraf) + ":" + sanitizeTags(tags[key], telegraf);
+    });
+  }
+}
+
+/**
+ * Overrides tags in parent with tags from child with the same name (case sensitive) and return the result as new
+ * array. parent and child are not mutated.
+ */
+function overrideTags (parent, child, telegraf) {
+  var childCopy = {};
+  var toAppend = [];
+  formatTags(child, telegraf).forEach(function (tag) {
+    var idx = typeof tag === 'string' ? tag.indexOf(':') : -1;
+    if (idx < 1) { // Not found or first character
+      toAppend.push(tag);
+    } else {
+      childCopy[tag.substring(0, idx)] = tag.substring(idx + 1);
+    }
+  });
+  var result = parent.map(function (tag) {
+    var idx = typeof tag === 'string' ? tag.indexOf(':') : -1;
+    if (idx < 1) { // Not found or first character
+      return tag;
+    }
+    var key = tag.substring(0, idx);
+    if (childCopy.hasOwnProperty(key)) {
+      var value = childCopy[key];
+      delete childCopy[key];
+      return key + ':' + value;
+    }
+    return tag;
+  });
+  Object.keys(childCopy).forEach(function (key) {
+    result.push(key + ':' + childCopy[key]);
+  });
+  return result.concat(toAppend);
+}
+
+// Formats a date for use with DataDog
+function formatDate(date) {
+  var timestamp;
+  if (date instanceof Date) {
+    // Datadog expects seconds.
+    timestamp = Math.round(date.getTime() / 1000);
+  } else if (date instanceof Number) {
+    // Make sure it is an integer, not a float.
+    timestamp = Math.round(date);
+  }
+  return timestamp;
+}
+
+// Converts int to a string IP
+function intToIP(int) {
+  var part1 = int & 255;
+  var part2 = ((int >> 8) & 255);
+  var part3 = ((int >> 16) & 255);
+  var part4 = ((int >> 24) & 255);
+
+  return part4 + "." + part3 + "." + part2 + "." + part1;
+}
+
+// Returns the system default interface on Linux
+function getDefaultRoute() {
+  try {
+    var fileContents = fs.readFileSync('/proc/net/route', 'utf8');
+    var routes = fileContents.split('\n');
+    for (var routeIdx in routes) {
+      var fields = routes[routeIdx].trim().split('\t');
+      if (fields[1] === '00000000') {
+        var address = fields[2];
+        // Convert to little endian by splitting every 2 digits and reversing that list
+        var littleEndianAddress = address.match(/.{2}/g).reverse().join("");
+        return intToIP(parseInt(littleEndianAddress, 16));
+      }
+    }
+  } catch (e) {
+    console.error('Could not get default route from /proc/net/route');
+  }
+  return null;
+}
+
+module.exports = {
+  formatTags: formatTags,
+  overrideTags: overrideTags,
+  formatDate: formatDate,
+  getDefaultRoute: getDefaultRoute
+};

--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -1,0 +1,267 @@
+"use strict";
+
+var helpers = require('./helpers');
+
+function applyStatsFns (Client) {
+  /**
+   * Represents the timing stat
+   * @param stat {String|Array} The stat(s) to send
+   * @param time {Number} The time in milliseconds to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
+    this.sendAll(stat, time, 'ms', sampleRate, tags, callback);
+  };
+
+  /**
+   * Represents the timing stat by recording the duration a function takes to run (in milliseconds)
+   * @param func {Function} The function to run
+   * @param stat {String|Array} The stat(s) to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.timer = function (func, stat, sampleRate, tags, callback) {
+    var _this = this;
+
+    return function () {
+      var start = process.hrtime();
+      try {
+        return func.apply(null, arguments);
+      } finally {
+        // get duration in milliseconds
+        var duration = process.hrtime(start)[1] / 1000000;
+
+        _this.timing(
+          stat,
+          duration,
+          sampleRate,
+          tags,
+          callback
+        );
+      }
+    };
+  };
+
+  /**
+   * Increments a stat by a specified amount
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
+    // allow use of tags without explicit value or sampleRate
+    if (arguments.length < 3) {
+      if (typeof value !== 'number') {
+        tags = value;
+        value = undefined;
+      }
+    }
+    // we explicitly check for undefined and null (and don't do a "! value" check)
+    // so that 0 values are allowed and sent through as-is
+    if (value === undefined || value === null) {
+      value = 1;
+    }
+    this.sendAll(stat, value, 'c', sampleRate, tags, callback);
+  };
+
+  /**
+   * Decrements a stat by a specified amount
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) {
+    this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
+  };
+
+  /**
+   * Represents the histogram stat
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.histogram = function (stat, value, sampleRate, tags, callback) {
+    this.sendAll(stat, value, 'h', sampleRate, tags, callback);
+  };
+
+  /**
+   * Represents the distribution stat
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.distribution = function (stat, value, sampleRate, tags, callback) {
+    this.sendAll(stat, value, 'd', sampleRate, tags, callback);
+  };
+
+
+  /**
+   * Gauges a stat by a specified amount
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.gauge = function (stat, value, sampleRate, tags, callback) {
+    this.sendAll(stat, value, 'g', sampleRate, tags, callback);
+  };
+
+  /**
+   * Counts unique values by a specified amount
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.unique = Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
+    this.sendAll(stat, value, 's', sampleRate, tags, callback);
+  };
+
+  /**
+   * Send a service check
+   * @param name {String} The name of the service check
+   * @param status {Number=} The status of the service check (0 to 3).
+   * @param options
+   *   @option date_happened {Date} Assign a timestamp to the event. Default is now.
+   *   @option hostname {String} Assign a hostname to the check.
+   *   @option message {String} Assign a message to the check.
+   * @param tags {Array=} The Array of tags to add to the check. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.check = function (name, status, options, tags, callback) {
+    if (this.telegraf) {
+      var err = new Error('Not supported by Telegraf / InfluxDB');
+      if (callback) {
+        return callback(err);
+      }
+      else if (this.errorHandler) {
+        return this.errorHandler(err);
+      }
+
+      throw err;
+    }
+
+    var check = ['_sc', this.prefix + name + this.suffix, status],
+      metadata = options || {};
+
+    if (metadata.date_happened) {
+      var timestamp = helpers.formatDate(metadata.date_happened);
+      if (timestamp) {
+        check.push('d:' + timestamp);
+      }
+    }
+    if (metadata.hostname) {
+      check.push('h:' + metadata.hostname);
+    }
+
+    var mergedTags = this.globalTags;
+    if (tags && typeof(tags) === "object") {
+      mergedTags = helpers.overrideTags(mergedTags, tags, this.telegraf);
+    }
+    if (mergedTags.length > 0) {
+      check.push('#' + mergedTags.join(','));
+    }
+
+    // message has to be the last part of a service check
+    if (metadata.message) {
+      check.push('m:' + metadata.message);
+    }
+
+    // allow for tags to be omitted and callback to be used in its place
+    if(typeof tags === 'function' && callback === undefined) {
+      callback = tags;
+    }
+
+    var message = check.join('|');
+    // Service checks are unique in that message has to be the last element in
+    // the stat if provided, so we can't append tags like other checks. This
+    // directly calls the `_send` method to avoid appending tags, since we've
+    // already added them.
+    this._send(message, callback);
+  };
+
+  /**
+   * Send on an event
+   * @param title {String} The title of the event
+   * @param text {String} The description of the event.  Optional- title is used if not given.
+   * @param options
+   *   @option date_happened {Date} Assign a timestamp to the event. Default is now.
+   *   @option hostname {String} Assign a hostname to the event.
+   *   @option aggregation_key {String} Assign an aggregation key to the event, to group it with some others.
+   *   @option priority {String} Can be ‘normal’ or ‘low’. Default is 'normal'.
+   *   @option source_type_name {String} Assign a source type to the event.
+   *   @option alert_type {String} Can be ‘error’, ‘warning’, ‘info’ or ‘success’. Default is 'info'.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.event = function (title, text, options, tags, callback) {
+    if (this.telegraf) {
+      var err = new Error('Not supported by Telegraf / InfluxDB');
+      if (callback) {
+        return callback(err);
+      }
+      else if (this.errorHandler) {
+        return this.errorHandler(err);
+      }
+
+      throw err;
+    }
+
+    // Convert to strings
+    var message,
+        msgTitle = String(title ? title : ''),
+        msgText = String(text ? text : msgTitle);
+    // Escape new lines (unescaping is supported by DataDog)
+    msgText = msgText.replace(/\n/g, '\\n');
+
+    // start out the message with the event-specific title and text info
+    message = '_e{' + msgTitle.length + ',' + msgText.length + '}:' + msgTitle + '|' + msgText;
+
+    // add in the event-specific options
+    if (options) {
+      if (options.date_happened) {
+        var timestamp = helpers.formatDate(options.date_happened);
+        if (timestamp) {
+          message += '|d:' + timestamp;
+        }
+      }
+      if (options.hostname) {
+        message += '|h:' + options.hostname;
+      }
+      if (options.aggregation_key) {
+        message += '|k:' + options.aggregation_key;
+      }
+      if (options.priority) {
+        message += '|p:' + options.priority;
+      }
+      if (options.source_type_name) {
+        message += '|s:' + options.source_type_name;
+      }
+      if (options.alert_type) {
+        message += '|t:' + options.alert_type;
+      }
+    }
+
+    // allow for tags to be omitted and callback to be used in its place
+    if(typeof tags === 'function' && callback === undefined) {
+      callback = tags;
+    }
+
+    this.send(message, tags, callback);
+  };
+}
+
+module.exports = applyStatsFns;

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,9 +1,10 @@
 "use strict";
 
-var dgram = require('dgram'),
-    util = require('util'),
-    dns   = require('dns'),
-    fs    = require('fs');
+var dgram         = require('dgram'),
+    util          = require('util'),
+    dns           = require('dns'),
+    helpers       = require('./helpers'),
+    applyStatsFns = require('./statsFunctions');
 
 /**
  * The UDP Client for StatsD
@@ -54,7 +55,8 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.suffix      = options.suffix || '';
   this.socket      = options.isChild ? options.socket : dgram.createSocket('udp4');
   this.mock        = options.mock;
-  this.globalTags  = typeof options.globalTags === "object" ? formatTags(options.globalTags, options.telegraf) : [];
+  this.globalTags  = typeof options.globalTags === "object" ?
+      helpers.formatTags(options.globalTags, options.telegraf) : [];
   this.telegraf    = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;
   this.sampleRate  = options.sampleRate || 1;
@@ -90,7 +92,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   }
 
   if(options.useDefaultRoute) {
-    var defaultRoute = getDefaultRoute();
+    var defaultRoute = helpers.getDefaultRoute();
     if (defaultRoute) {
       console.log('Got ' + defaultRoute + " for the system's default route");
       this.host = defaultRoute;
@@ -105,266 +107,7 @@ var Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   };
 };
 
-/**
- * Represents the timing stat
- * @param stat {String|Array} The stat(s) to send
- * @param time {Number} The time in milliseconds to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.timing = function (stat, time, sampleRate, tags, callback) {
-  this.sendAll(stat, time, 'ms', sampleRate, tags, callback);
-};
-
-/**
- * Represents the timing stat by recording the duration a function takes to run (in milliseconds)
- * @param func {Function} The function to run
- * @param stat {String|Array} The stat(s) to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.timer = function (func, stat, sampleRate, tags, callback) {
-  var _this = this;
-
-  return function () {
-    var start = process.hrtime();
-    try {
-      return func.apply(null, arguments);
-    } finally {
-      // get duration in milliseconds
-      var duration = process.hrtime(start)[1] / 1000000;
-
-      _this.timing(
-        stat,
-        duration,
-        sampleRate,
-        tags,
-        callback
-      );
-    }
-  };
-};
-
-/**
- * Increments a stat by a specified amount
- * @param stat {String|Array} The stat(s) to send
- * @param value The value to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.increment = function (stat, value, sampleRate, tags, callback) {
-  // allow use of tags without explicit value or sampleRate
-  if (arguments.length < 3) {
-    if (typeof value !== 'number') {
-      tags = value;
-      value = undefined;
-    }
-  }
-  // we explicitly check for undefined and null (and don't do a "! value" check)
-  // so that 0 values are allowed and sent through as-is
-  if (value === undefined || value === null) {
-    value = 1;
-  }
-  this.sendAll(stat, value, 'c', sampleRate, tags, callback);
-};
-
-/**
- * Decrements a stat by a specified amount
- * @param stat {String|Array} The stat(s) to send
- * @param value The value to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.decrement = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, -value || -1, 'c', sampleRate, tags, callback);
-};
-
-/**
- * Represents the histogram stat
- * @param stat {String|Array} The stat(s) to send
- * @param value The value to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.histogram = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 'h', sampleRate, tags, callback);
-};
-
-/**
- * Represents the distribution stat
- * @param stat {String|Array} The stat(s) to send
- * @param value The value to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.distribution = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 'd', sampleRate, tags, callback);
-};
-
-
-/**
- * Gauges a stat by a specified amount
- * @param stat {String|Array} The stat(s) to send
- * @param value The value to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.gauge = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 'g', sampleRate, tags, callback);
-};
-
-/**
- * Counts unique values by a specified amount
- * @param stat {String|Array} The stat(s) to send
- * @param value The value to send
- * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.unique =
-Client.prototype.set = function (stat, value, sampleRate, tags, callback) {
-  this.sendAll(stat, value, 's', sampleRate, tags, callback);
-};
-
-/**
- * Send a service check
- * @param name {String} The name of the service check
- * @param status {Number=} The status of the service check (0 to 3).
- * @param options
- *   @option date_happened {Date} Assign a timestamp to the event. Default is now.
- *   @option hostname {String} Assign a hostname to the check.
- *   @option message {String} Assign a message to the check.
- * @param tags {Array=} The Array of tags to add to the check. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.check = function(name, status, options, tags, callback) {
-  if (this.telegraf) {
-    var err = new Error('Not supported by Telegraf / InfluxDB');
-    if (callback) {
-      return callback(err);
-    }
-    else if (this.errorHandler) {
-      return this.errorHandler(err);
-    }
-
-    throw err;
-  }
-
-  var check = ['_sc', this.prefix + name + this.suffix, status],
-    metadata = options || {};
-
-  if (metadata.date_happened) {
-    var timestamp = formatDate(metadata.date_happened);
-    if (timestamp) {
-      check.push('d:' + timestamp);
-    }
-  }
-  if (metadata.hostname) {
-    check.push('h:' + metadata.hostname);
-  }
-
-  var mergedTags = this.globalTags;
-  if (tags && typeof(tags) === "object") {
-    mergedTags = overrideTags(mergedTags, tags, this.telegraf);
-  }
-  if (mergedTags.length > 0) {
-    check.push('#' + mergedTags.join(','));
-  }
-
-  // message has to be the last part of a service check
-  if (metadata.message) {
-    check.push('m:' + metadata.message);
-  }
-
-  // allow for tags to be omitted and callback to be used in its place
-  if(typeof tags === 'function' && callback === undefined) {
-    callback = tags;
-  }
-
-  var message = check.join('|');
-  // Service checks are unique in that message has to be the last element in
-  // the stat if provided, so we can't append tags like other checks. This
-  // directly calls the `_send` method to avoid appending tags, since we've
-  // already added them.
-  this._send(message, callback);
-};
-
-/**
- * Send on an event
- * @param title {String} The title of the event
- * @param text {String} The description of the event.  Optional- title is used if not given.
- * @param options
- *   @option date_happened {Date} Assign a timestamp to the event. Default is now.
- *   @option hostname {String} Assign a hostname to the event.
- *   @option aggregation_key {String} Assign an aggregation key to the event, to group it with some others.
- *   @option priority {String} Can be ‘normal’ or ‘low’. Default is 'normal'.
- *   @option source_type_name {String} Assign a source type to the event.
- *   @option alert_type {String} Can be ‘error’, ‘warning’, ‘info’ or ‘success’. Default is 'info'.
- * @param tags {Array=} The Array of tags to add to metrics. Optional.
- * @param callback {Function=} Callback when message is done being delivered. Optional.
- */
-Client.prototype.event = function(title, text, options, tags, callback) {
-  if (this.telegraf) {
-    var err = new Error('Not supported by Telegraf / InfluxDB');
-    if (callback) {
-      return callback(err);
-    }
-    else if (this.errorHandler) {
-      return this.errorHandler(err);
-    }
-
-    throw err;
-  }
-
-  // Convert to strings
-  var message,
-      msgTitle = String(title ? title : ''),
-      msgText = String(text ? text : msgTitle);
-  // Escape new lines (unescaping is supported by DataDog)
-  msgText = msgText.replace(/\n/g, '\\n');
-
-  // start out the message with the event-specific title and text info
-  message = '_e{' + msgTitle.length + ',' + msgText.length + '}:' + msgTitle + '|' + msgText;
-
-  // add in the event-specific options
-  if (options) {
-    if (options.date_happened) {
-      var timestamp = formatDate(options.date_happened);
-      if (timestamp) {
-        message += '|d:' + timestamp;
-      }
-    }
-    if (options.hostname) {
-      message += '|h:' + options.hostname;
-    }
-    if (options.aggregation_key) {
-      message += '|k:' + options.aggregation_key;
-    }
-    if (options.priority) {
-      message += '|p:' + options.priority;
-    }
-    if (options.source_type_name) {
-      message += '|s:' + options.source_type_name;
-    }
-    if (options.alert_type) {
-      message += '|t:' + options.alert_type;
-    }
-  }
-
-  // allow for tags to be omitted and callback to be used in its place
-  if(typeof tags === 'function' && callback === undefined) {
-    callback = tags;
-  }
-
-  this.send(message, tags, callback);
-};
+applyStatsFns(Client);
 
 /**
  * Checks if stats is an array and sends all stats calling back once all have sent
@@ -463,7 +206,7 @@ Client.prototype.sendStat = function (stat, value, type, sampleRate, tags, callb
 Client.prototype.send = function (message, tags, callback) {
   var mergedTags = this.globalTags;
   if(tags && typeof tags === "object"){
-    mergedTags = overrideTags(mergedTags, tags, this.telegraf);
+    mergedTags = helpers.overrideTags(mergedTags, tags, this.telegraf);
   }
   if(mergedTags.length > 0){
     if (this.telegraf) {
@@ -629,7 +372,7 @@ var ChildClient = function (parent, options) {
     mock        : parent.mock,
     // Append child's tags to parent's tags
     globalTags  : typeof options.globalTags === "object" ?
-        overrideTags(parent.globalTags, options.globalTags, parent.telegraf) : parent.globalTags,
+        helpers.overrideTags(parent.globalTags, options.globalTags, parent.telegraf) : parent.globalTags,
     maxBufferSize : parent.maxBufferSize,
     bufferFlushInterval: parent.bufferFlushInterval,
     telegraf    : parent.telegraf
@@ -647,101 +390,6 @@ util.inherits(ChildClient, Client);
 Client.prototype.childClient = function(options) {
   return new ChildClient(this, options);
 };
-
-function sanitizeTags(value, telegraf) {
-  var blacklist = telegraf ? /:|\|/g : /:|\||@|,/g;
-  // Replace reserved chars with underscores.
-  return (value + "").replace(blacklist, "_");
-}
-
-function formatTags(tags, telegraf) {
-  if (Array.isArray(tags)) {
-    return tags;
-
-  } else {
-    return Object.keys(tags).map(function (key) {
-      return sanitizeTags(key, telegraf) + ":" + sanitizeTags(tags[key], telegraf);
-    });
-  }
-}
-
-/**
- * Overrides tags in parent with tags from child with the same name (case sensitive) and return the result as new
- * array. parent and child are not mutated.
- */
-function overrideTags (parent, child, telegraf) {
-  var childCopy = {};
-  var toAppend = [];
-  formatTags(child, telegraf).forEach(function (tag) {
-    var idx = typeof tag === 'string' ? tag.indexOf(':') : -1;
-    if (idx < 1) { // Not found or first character
-      toAppend.push(tag);
-    } else {
-      childCopy[tag.substring(0, idx)] = tag.substring(idx + 1);
-    }
-  });
-  var result = parent.map(function (tag) {
-    var idx = typeof tag === 'string' ? tag.indexOf(':') : -1;
-    if (idx < 1) { // Not found or first character
-      return tag;
-    }
-    var key = tag.substring(0, idx);
-    if (childCopy.hasOwnProperty(key)) {
-      var value = childCopy[key];
-      delete childCopy[key];
-      return key + ':' + value;
-    }
-    return tag;
-  });
-  Object.keys(childCopy).forEach(function (key) {
-    result.push(key + ':' + childCopy[key]);
-  });
-  return result.concat(toAppend);
-}
-
-// Formats a date for use with DataDog
-function formatDate(date) {
-  var timestamp;
-  if (date instanceof Date) {
-    // Datadog expects seconds.
-    timestamp = Math.round(date.getTime() / 1000);
-  } else if (date instanceof Number) {
-    // Make sure it is an integer, not a float.
-    timestamp = Math.round(date);
-  }
-  return timestamp;
-}
-
-// Converts int to a string IP
-function intToIP(int) {
-  var part1 = int & 255;
-  var part2 = ((int >> 8) & 255);
-  var part3 = ((int >> 16) & 255);
-  var part4 = ((int >> 24) & 255);
-
-  return part4 + "." + part3 + "." + part2 + "." + part1;
-}
-
-// Returns the system default interface on Linux
-function getDefaultRoute() {
-  try {
-    var fileContents = fs.readFileSync('/proc/net/route', 'utf8');
-    var routes = fileContents.split('\n');
-    for (var routeIdx in routes) {
-      var fields = routes[routeIdx].trim().split('\t');
-      if (fields[1] === '00000000') {
-        var address = fields[2];
-        // Convert to little endian by splitting every 2 digits and reversing that list
-        var littleEndianAddress = address.match(/.{2}/g).reverse().join("");
-        return intToIP(parseInt(littleEndianAddress, 16));
-      }
-    }
-  } catch (e) {
-    console.error('Could not get default route from /proc/net/route');
-  }
-  return null;
-}
-
 
 exports = module.exports = Client;
 exports.StatsD = Client;

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,6 +328,2636 @@
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
+    "nyc": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.8.0.tgz",
+      "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.4.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.1.0",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.2.1",
+        "yargs": "11.1.0",
+        "yargs-parser": "8.1.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "atob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.6",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
+          }
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-cache": "0.2.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-odd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.26.1",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "semver": "5.5.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-visit": "1.0.1"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-plain-object": "2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "nanomatch": {
+          "version": "1.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            }
+          }
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "1.2.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ret": "0.1.15"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "3.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend-shallow": "3.0.2"
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "3.1.10",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              }
+            }
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            }
+          }
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
+              }
+            }
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "use": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "6.0.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "9.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
+    "coverage": "nyc --reporter=lcov npm test",
     "test": "mocha -R spec",
     "lint": "jshint lib/**.js test/**.js",
     "pretest": "npm run lint"
@@ -37,7 +38,8 @@
   "dependencies": {},
   "devDependencies": {
     "jshint": "2.x",
-    "mocha": "2.x"
+    "mocha": "2.x",
+    "nyc": "11.x"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
<img width="616" alt="screen shot 2018-05-28 at 10 23 58 pm" src="https://user-images.githubusercontent.com/9580545/40635011-f9b9ffd0-62c5-11e8-8d37-c34af400d3d8.png">

#62 
* moves non-client-specific functions to `helpers.js`, and stat-specific functions (ie. `increment`, `set`, `timer`) to `statsFunctions.js` to mentally separate concerns and reduce single-file syndrome
* Adds nyc to create coverage reports