### PR TITLE
Typescript declaration for the 'timer' method

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -74,6 +74,7 @@ declare module "hot-shots" {
     decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
 
     timing(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    timer(func: (...args: any[]) => any, stat: string, sampleRate: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
     histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
     distribution(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
     gauge(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;


### PR DESCRIPTION
Tested with a project written in typescript by locally linking the `hot-shots` module with this change applied and issuing metrics with a call like this:

```
this.metrics.timer(this.someMethod.bind(this), 'someMethodStats')(someObject)
```