### PR TITLE
Add overload types for stats functions

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -61,29 +61,62 @@ declare module "hot-shots" {
   }
 
   export type StatsCb = (error: Error | undefined, bytes: any) => void;
-  export type StatsCall = (stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb) => void;
 
   export class StatsD {
     constructor(options?: ClientOptions);
     childClient(options?: ChildClientOptions): StatsD;
 
-    increment(stat: string): void;
+    increment(stat: string, tags?: Tags): void;
     increment(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    increment(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    increment(stat: string | string[], value: number, callback?: StatsCb): void;
+    increment(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
 
     decrement(stat: string): void;
     decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    decrement(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    decrement(stat: string | string[], value: number, callback?: StatsCb): void;
+    decrement(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
 
     timing(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    timer(func: (...args: any[]) => any, stat: string, sampleRate: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+    timing(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    timing(stat: string | string[], value: number, callback?: StatsCb): void;
+    timing(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+
+    timer(func: (...args: any[]) => any, stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], value: number, callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): (...args: any[]) => any;
+
     histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    histogram(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    histogram(stat: string | string[], value: number, callback?: StatsCb): void;
+    histogram(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+
     distribution(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    distribution(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    distribution(stat: string | string[], value: number, callback?: StatsCb): void;
+    distribution(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+
     gauge(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    gauge(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    gauge(stat: string | string[], value: number, callback?: StatsCb): void;
+    gauge(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+
     set(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    set(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    set(stat: string | string[], value: number, callback?: StatsCb): void;
+    set(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+
     unique(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
 
     close(callback: () => void): void;
 
     event(title: string, text?: string, options?: EventOptions, tags?: Tags, callback?: StatsCb): void;
+    event(title: string, text?: string, options?: EventOptions, callback?: StatsCb): void;
     check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
 
     public CHECKS: DatadogChecks;


### PR DESCRIPTION
Stats functions provided by hot-shots allow certain parameters to be safely omitted without mistaking them for others. A common example is omitting the `sampleRate` parameter, but still using `tags` and/or a `callback` function. Reviewing those functions, that looks to be the case (#43 aside)

As written, the types allow for omitting certain parameters, but only if all parameters before it are included. The example above of omitting `sampleRate`, but still using `tags` was not properly expressed by the existing types.

This PR adds overload types for the stat collection functions to reflect their actual capabilities, tested by replacing the types file in a separate typescript project and removing parameters with no typescript errors reported.