### PR TITLE
Types - adds in socket to StatsD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+## 5.6.1 (2018-6-4)
+* @MattySheikh Typescript: add socket type for StatsD class
+
 ## 5.6.0 (2018-6-3)
 * @drewen TypeScript: add overload types for stats functions
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -120,6 +120,7 @@ declare module "hot-shots" {
     check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
 
     public CHECKS: DatadogChecks;
+    public socket: dgram.Socket;
   }
 }
 


### PR DESCRIPTION
Issue
====
The following code presents multiple errors when trying to compile Typescript
```typescript
import { StatsD } from 'hot-shots';

const client = new StatsD();

client.socket.on('error', (error) => {
	console.error('Error!', error);
});
```

#### Errors
`Property 'socket' does not exist on type 'StatsD'.`
`Parameter 'error' implicitly has an 'any' type.`

Fix
====
Add `socket: dgram.Socket` to StatsD class type

I'm unaware of any workaround and haven't seen any issues opened with this. Please let me know if there's any other information needed or if any edits to this PR need to be made!