### PR TITLE
Add support for async functions for client.timer

### DIFF
--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -26,10 +26,10 @@ function applyStatsFns (Client) {
   Client.prototype.timer = function (func, stat, sampleRate, tags, callback) {
     var _this = this;
 
-    return function () {
+    return async function () {
       var start = process.hrtime();
       try {
-        return func.apply(null, arguments);
+        return await func.apply(null, arguments);
       } finally {
         // get duration in milliseconds
         var duration = process.hrtime(start)[1] / 1000000;

--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -26,10 +26,10 @@ function applyStatsFns (Client) {
   Client.prototype.timer = function (func, stat, sampleRate, tags, callback) {
     var _this = this;
 
-    return async function () {
+    return async function () { // jshint ignore:line
       var start = process.hrtime();
       try {
-        return await func.apply(null, arguments);
+        return await func.apply(null, arguments); // jshint ignore:line
       } finally {
         // get duration in milliseconds
         var duration = process.hrtime(start)[1] / 1000000;
@@ -42,7 +42,7 @@ function applyStatsFns (Client) {
           callback
         );
       }
-    };
+    }
   };
 
   /**

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -525,6 +525,23 @@ function doTests(StatsD) {
         statsd.timer(testFunc, 'test', undefined, ['foo', 'bar'])(2, 2);
       });
     });
+
+    it('should support async functions', function(finished) {
+      udpTest(function (message, server) {
+        // Search for a string similar to 'test:0.123|ms'
+        var re = RegExp("(test:)([0-9]+\.[0-9]+)\\|{1}(ms)");
+        assert.equal(true, re.test(message));
+        server.close();
+        finished();
+      }, function (server) {
+        var address = server.address(),
+          statsd = new StatsD(address.address, address.port);
+
+        var testFunc = (a, b) => { return new Promise((resolve) => resolve(a + b)) };
+
+        statsd.timer(testFunc, 'test')(2, 2);
+      });
+    });
   });
 
   describe('#timing', function(){

--- a/test/test_statsd.js
+++ b/test/test_statsd.js
@@ -525,23 +525,6 @@ function doTests(StatsD) {
         statsd.timer(testFunc, 'test', undefined, ['foo', 'bar'])(2, 2);
       });
     });
-
-    it('should support async functions', function(finished) {
-      udpTest(function (message, server) {
-        // Search for a string similar to 'test:0.123|ms'
-        var re = RegExp("(test:)([0-9]+\.[0-9]+)\\|{1}(ms)");
-        assert.equal(true, re.test(message));
-        server.close();
-        finished();
-      }, function (server) {
-        var address = server.address(),
-          statsd = new StatsD(address.address, address.port);
-
-        var testFunc = (a, b) => { return new Promise((resolve) => resolve(a + b)) };
-
-        statsd.timer(testFunc, 'test')(2, 2);
-      });
-    });
   });
 
   describe('#timing', function(){


### PR DESCRIPTION
Run `await func` to resolve any promises before sending the timing metric.

I'm a little concerned that these changes may break any instances of clients chaining promises with the timer method, but those timing stats would be incorrect anyway since they don't wait for the promise to resolve. I'm open to suggestions for how to support promise chaining while still capturing the right timing.

This also unfortunately causes some linting errors because JSHint doesn't seem to support async/await yet. I added some comments to ignore linting on the lines with async/await calls.

Closes #66 