### PR TITLE
Fix `timer` function in `lib/statsFunctions.js`…

### DIFF
--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -32,7 +32,10 @@ function applyStatsFns (Client) {
         return func.apply(null, arguments);
       } finally {
         // get duration in milliseconds
-        var duration = process.hrtime(start)[1] / 1000000;
+        var durationComponents = process.hrtime(start);
+        var seconds = durationComponents[0];
+        var nanoseconds = durationComponents[1];
+        var duration = seconds * 1000 + nanoseconds / 10E6;
 
         _this.timing(
           stat,


### PR DESCRIPTION
… to properly interpret `process.hrtime`

According to the [node documentation](https://nodejs.org/api/process.html#process_process_hrtime_time), the concluding call to `process.hrtime`:
>returns the current high-resolution real time in a `[seconds, nanoseconds]` tuple `Array`, where `nanoseconds` is the remaining part of the real time that can't be represented in second precision.

The `timer` function was previously throwing away the seconds part; this PR includes them.