### PR TITLE
Add increment with tags example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ The check method has the following API:
 
   // Incrementing multiple items
   client.increment(['these', 'are', 'different', 'stats']);
+  
+  // Incrementing with tags
+  client.increment('my_counter', ['foo', 'bar']);
 
   // Sampling, this will sample 25% of the time the StatsD Daemon will compensate for sampling
   client.increment('my_counter', 1, 0.25);


### PR DESCRIPTION
This wasn't clear to me at first because the increment value is inferred. This commit adds an explicit example so future folks don't have to dive into the source code.