### PR TITLE
Fix types: default export is the `StatsD` class

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -124,5 +124,4 @@ declare module "hot-shots" {
   }
 }
 
-declare const StatsDClient: StatsD;
-export default StatsDClient;
+export default StatsD;


### PR DESCRIPTION
Node REPL:

```
> const StatsD = require('hot-shots')
undefined
> typeof StatsD
'function'
> new StatsD()
Client {
  host: 'localhost',
// ...
```