### PR TITLE
Add mockBuffer to types.d.ts so TS tests may access for testing purposes

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -125,6 +125,7 @@ declare module "hot-shots" {
     check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
 
     public CHECKS: DatadogChecks;
+    public mockBuffer?: string[];
     public socket: dgram.Socket;
   }
 }


### PR DESCRIPTION
Wanted to access this in TS to validate the content of the messages during
testing. Found this wasn't there. So here we are.