### PR TITLE
Handle case when value is not an number

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,7 @@ const fs = require('fs');
 function sanitizeTags(value, telegraf) {
   const blacklist = telegraf ? /:|\|/g : /:|\||@|,/g;
   // Replace reserved chars with underscores.
-  return value.replace(blacklist, '_');
+  return String(value).replace(blacklist, '_');
 }
 
 /**


### PR DESCRIPTION
Handle case, when send number as a tag value. Tag example: `{'year': 2018}`