### PR TITLE
Fix the timer function type definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -83,10 +83,10 @@ declare module "hot-shots" {
     timing(stat: string | string[], value: number, callback?: StatsCb): void;
     timing(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
 
-    timer(func: (...args: any[]) => any, stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
-    timer(func: (...args: any[]) => any, stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
-    timer(func: (...args: any[]) => any, stat: string | string[], value: number, callback?: StatsCb): (...args: any[]) => any;
-    timer(func: (...args: any[]) => any, stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], callback?: StatsCb): (...args: any[]) => any;
+    timer(func: (...args: any[]) => any, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: any[]) => any;
 
     asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: any[]) => Promise<T>;
     asyncTimer<T>(func: (...args: any[]) => Promise<T>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: any[]) => Promise<T>;


### PR DESCRIPTION
The timer function doesn't take a `value` parameter so removing it.

https://github.com/brightcove/hot-shots/blob/master/lib/statsFunctions.js#L29

