### PR TITLE
Fix error handler to only happen again on errors

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -330,12 +330,14 @@ Client.prototype.sendMessage = function (message, callback) {
     }
     if (callback) {
       callback(errFormatted);
-    } else if (this.errorHandler) {
-      this.errorHandler(errFormatted);
-    } else if (errFormatted) {
-      console.log(String(errFormatted));
-      // emit error ourselves on the socket for backwards compatibility
-      this.socket.emit('error', errFormatted);
+    } else if (err) {
+      if (this.errorHandler) {
+        this.errorHandler(errFormatted);
+      } else if (errFormatted) {
+        console.log(String(errFormatted));
+        // emit error ourselves on the socket for backwards compatibility
+        this.socket.emit('error', errFormatted);
+      }
     }
   };
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -330,10 +330,10 @@ Client.prototype.sendMessage = function (message, callback) {
     }
     if (callback) {
       callback(errFormatted);
-    } else if (err) {
+    } else if (errFormatted) {
       if (this.errorHandler) {
         this.errorHandler(errFormatted);
-      } else if (errFormatted) {
+      } else {
         console.log(String(errFormatted));
         // emit error ourselves on the socket for backwards compatibility
         this.socket.emit('error', errFormatted);

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -10,8 +10,99 @@ describe('#errorHandling', () => {
   let server;
   let statsd;
 
+  // we have some tests first outside of the normal testTypes() setup as we want to
+  // test with a broken server, which is just set up with tcp
+
+  it('should use errorHandler when server is broken', done => {
+    server = createServer('tcp_broken', address => {
+      statsd = createHotShotsClient({
+        host: address.address,
+        port: address.port,
+        protocol: 'tcp',
+        errorHandler(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          done();
+        }
+      }, 'client');
+      statsd.increment('a', 42, null);
+      server.on('metrics', () => {
+        assert.ok(false);
+      });
+    });
+  });
+
+  it('should use errorHandler when server is broken and using buffers', done => {
+    server = createServer('tcp_broken', address => {
+      statsd = createHotShotsClient({
+        host: address.address,
+        port: address.port,
+        protocol: 'tcp',
+        maxBufferSize: 1,
+        errorHandler(err) {
+          assert.equal(err.code, 'ERR_ASSERTION');
+          done();
+        }
+      }, 'client');
+      statsd.increment('a', 42, null);
+      server.on('metrics', () => {
+        assert.ok(false);
+      });
+    });
+  });
+
   testTypes().forEach(([description, serverType, clientType]) => {
     describe(description, () => {
+      it('should not use errorHandler when there is not an error', done => {
+        server = createServer(serverType, address => {
+          statsd = createHotShotsClient({
+            host: address.address,
+            port: address.port,
+            protocol: serverType,
+            errorHandler() {
+              assert.ok(false);
+            }
+          }, clientType);
+          statsd.increment('a', 42, null);
+          server.on('metrics', () => {
+            done();
+          });
+        });
+      });
+
+      it('should not use errorHandler when there is not an error and using buffers', done => {
+        server = createServer(serverType, address => {
+          statsd = createHotShotsClient({
+            host: address.address,
+            port: address.port,
+            protocol: serverType,
+            maxBufferSize: 1,
+            errorHandler() {
+              assert.ok(false);
+            }
+          }, clientType);
+          statsd.increment('a', 42, null);
+          server.on('metrics', () => {
+            done();
+          });
+        });
+      });
+
+      it('should not use errorHandler when there is an increment send error', done => {
+        server = createServer(serverType, address => {
+          statsd = createHotShotsClient({
+            host: address.address,
+            port: address.port,
+            protocol: serverType,
+            errorHandler() {
+              assert.ok(false);
+            }
+          }, clientType);
+          statsd.increment('a', 42, null);
+          server.on('metrics', () => {
+            done();
+          });
+        });
+      });
 
       it('should use errorHandler for sendStat error', done => {
         server = createServer(serverType, address => {

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -13,24 +13,6 @@ describe('#errorHandling', () => {
   // we have some tests first outside of the normal testTypes() setup as we want to
   // test with a broken server, which is just set up with tcp
 
-  it('should use errorHandler when server is broken', done => {
-    server = createServer('tcp_broken', address => {
-      statsd = createHotShotsClient({
-        host: address.address,
-        port: address.port,
-        protocol: 'tcp',
-        errorHandler(err) {
-          assert.ok(err);
-          done();
-        }
-      }, 'client');
-      statsd.increment('a', 42, null);
-      server.on('metrics', () => {
-        assert.ok(false);
-      });
-    });
-  });
-
   it('should use errorHandler when server is broken and using buffers', done => {
     // sometimes two errors show up, one with the initial connection
     let seenError = false;

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -75,23 +75,6 @@ describe('#errorHandling', () => {
         });
       });
 
-      it('should not use errorHandler when there is an increment send error', done => {
-        server = createServer(serverType, address => {
-          statsd = createHotShotsClient({
-            host: address.address,
-            port: address.port,
-            protocol: serverType,
-            errorHandler() {
-              assert.ok(false);
-            }
-          }, clientType);
-          statsd.increment('a', 42, null);
-          server.on('metrics', () => {
-            done();
-          });
-        });
-      });
-
       it('should use errorHandler for sendStat error', done => {
         server = createServer(serverType, address => {
           const err = new Error('Boom!');

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -8,6 +8,7 @@ const CHILD_CLIENT = 'child client';
 const CHILD_CHILD_CLIENT = 'child child client';
 const TCP = 'tcp';
 const UDP = 'udp';
+const TCP_BROKEN = 'tcp_broken';
 // tcp puts a newline at the end but udp does not
 const TCP_METRIC_END = '\n';
 const UDP_METRIC_END = '';
@@ -92,6 +93,22 @@ function createServer(serverType, onListening) {
       });
     });
     server.on('listening', () => {
+      onListening(server.address());
+    });
+
+    server.listen(0, '127.0.0.1');
+  }
+  else if (serverType === TCP_BROKEN) {
+    server = net.createServer(socket => {
+      socket.setEncoding('ascii');
+      socket.on('data', data => {
+        if (data) {
+          server.emit('metrics', data);
+        }
+      });
+      socket.destroy();
+    });
+    server.on('listening', (socket) => {
       onListening(server.address());
     });
 


### PR DESCRIPTION
As noted in https://github.com/brightcove/hot-shots/pull/96 this behavior changed recently.  Fix and add a bunch of tests in the area.