### PR TITLE
Fix syntax in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The check method has the following API:
 
 ```javascript
   var StatsD = require('hot-shots'),
-      client = new StatsD({ port: 8020, globalTags: { env: process.env.NODE_ENV, errorHandler: errorHandler });
+      client = new StatsD({ port: 8020, globalTags: { env: process.env.NODE_ENV }, errorHandler: errorHandler });
 
   // Timing: sends a timing command with the specified milliseconds
   client.timing('response_time', 42);


### PR DESCRIPTION
A missing `}` had me confused for a minute as to why `errorHandler` would be passed to the `globalTags` option. 😄 