### PR TITLE
add env vars support for dogstatsd host, port and entity id

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -167,7 +167,6 @@ module.exports = {
         "no-param-reassign": "off",
         "no-path-concat": "error",
         "no-plusplus": "off",
-        "no-process-env": "error",
         "no-process-exit": "error",
         "no-proto": "error",
         "no-prototype-builtins": "off",

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ You may also want to use the Datadog events support in here instead of other lib
 All initialization parameters are optional.
 
 Parameters (specified as one object passed into hot-shots):
-* `host`:        The host to send stats to `default: localhost`
-* `port`:        The port to send stats to `default: 8125`
+* `host`:        The host to send stats to, if not set, the constructor tries to retrieve it from the `DD_AGENT_HOST` environment variable, `default: localhost`
+* `port`:        The port to send stats to, if not set, the constructor tries to retrieve it from the `DD_DOGSTATSD_PORT` environment variable, `default: 8125`
 * `prefix`:      What to prefix each stat name with `default: ''`
 * `suffix`:      What to suffix each stat name with `default: ''`
 * `globalize`:   Expose this StatsD instance globally? `default: false`
 * `cacheDns`:    Cache the initial dns lookup to *host* `default: false`
 * `mock`:        Create a mock StatsD instance, sending no stats to the server and allowing data to be read from mockBuffer? `default: false`
-* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. `default: {}`
+* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. The *Datadog* `dd.internal.entity_id` tag is appended to `globalTags` from the `DD_ENTITY_ID` environment variable if the latter is set. `default: {}`
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0`
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -110,5 +110,6 @@ module.exports = {
   formatTags: formatTags,
   overrideTags: overrideTags,
   formatDate: formatDate,
-  getDefaultRoute: getDefaultRoute
+  getDefaultRoute: getDefaultRoute,
+  sanitizeTags: sanitizeTags
 };

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -61,8 +61,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   options.globalTags = options.globalTags || options.global_tags;
 
   this.protocol    = (options.protocol && options.protocol.toLowerCase());
-  this.host        = options.host || 'localhost';
-  this.port        = options.port || 8125;
+  this.host        = options.host || process.env.DD_AGENT_HOST || 'localhost';
+  this.port        = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix      = options.prefix || '';
   this.suffix      = options.suffix || '';
   this.socket      = options.isChild ? options.socket : createSocket(this, {
@@ -73,6 +73,12 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.mock        = options.mock;
   this.globalTags  = typeof options.globalTags === 'object' ?
       helpers.formatTags(options.globalTags, options.telegraf) : [];
+  if (process.env.DD_ENTITY_ID) {
+    this.globalTags = this.globalTags.filter((item) => {
+      return item.indexOf('dd.internal.entity_id:') !== 0;
+   });
+    this.globalTags.push('dd.internal.entity_id:'.concat(helpers.sanitizeTags(process.env.DD_ENTITY_ID)));
+  }
   this.telegraf    = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;
   this.sampleRate  = options.sampleRate || 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,6 +782,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1964,7 +1965,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",


### PR DESCRIPTION
Support of 3 environment variables for DogStatsD Client configuration:

`"DD_AGENT_HOST"` used to provide the Agent hostname.
`"DD_DOGSTATSD_PORT"` used to provide the DogStatsD port.
`"DD_ENTITY_ID"` used to provide an identifier to the Client.

If Client `host` and `port` constructor's arguments are not set, prioritize `"DD_AGENT_HOST"` and `"DD_DOGSTATSD_PORT"` over default values.
Add `"DD_ENTITY_ID"` as a global tag with the tag name `dd.internal.entity_id`.