### PR TITLE
Add max UDP datagram size validation

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -122,6 +122,16 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.bufferHolder = options.isChild ? options.bufferHolder : { buffer: '' };
   this.errorHandler = options.errorHandler;
 
+  if (this.maxBufferSize > 65507) {
+    const warningMessage = 'Warning! You have exceed max UDP datagram size 65507 bytes. maxBufferSize will set as 65507.  Details: https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback';
+    if (this.errorHandler) {
+      this.errorHandler(warningMessage);
+    } else {
+      console.warn(warningMessage);
+    }
+    this.maxBufferSize = 65507;
+  }
+
   // If we're mocking the client, create a buffer to record the outgoing calls.
   if (this.mock) {
     this.mockBuffer = [];


### PR DESCRIPTION
Add max UDP datagram size validation due to UDP protocol restriction. Details: https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback