### PR TITLE
Add in uds tests on Node 12

### DIFF
--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -81,7 +81,7 @@ function testTypes() {
     [`${TCP} ${CHILD_CLIENT}`, TCP, CHILD_CLIENT, TCP_METRIC_END]];
 
   // Not everywhere can run UDS, and we don't want to fail the tests in those places
-  if (os.platform() !== 'win32' &&  ! process.version.startsWith('v12.')) {
+  if (os.platform() !== 'win32') {
     testTypesArr.push([`${UDS} ${CLIENT}`, UDS, CLIENT, UDS_METRIC_END]);
     testTypesArr.push([`${UDS} ${CHILD_CLIENT}`, UDS, CLIENT, UDS_METRIC_END]);
   }
@@ -95,7 +95,7 @@ function testProtocolTypes() {
   const protTypesArr = [[`${UDP} ${CLIENT}`, UDP, CLIENT, UDP_METRIC_END],
     [`${TCP} ${CLIENT}`, TCP, CLIENT, TCP_METRIC_END]];
   // Not everywhere can run UDS, and we don't want to fail the tests in those places
-  if (os.platform() !== 'win32' &&  ! process.version.startsWith('v12.')) {
+  if (os.platform() !== 'win32') {
     protTypesArr.push([`${UDS} ${CLIENT}`, UDS, CLIENT, UDS_METRIC_END]);
   }
   return protTypesArr;


### PR DESCRIPTION
Forgot about this with https://github.com/brightcove/hot-shots/pull/112.  We do want the UDS tests to run now, and they did pass for me locally.