### PR TITLE
add options.udsGracefulErrorHandling to enable sockere-creation with …

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Parameters (specified as one object passed into hot-shots):
 * `useDefaultRoute`: Use the default interface on a Linux system. Useful when running in containers
 * `protocol`: Use `tcp` option for TCP protocol, or `uds` for the Unix Domain Socket protocol. Defaults to UDP otherwise
 * `path`: Used only when the protocol is `uds`. Defaults to `/var/run/datadog/dsd.socket`.
+* `udsGracefulErrorHandling`: Used only when the protocol is `uds`. Boolean indicating wether to handle socket errors gracefully. defaults falsey
+* `udsGracefulRestartRateLimit`: Used only when the protocol is `uds`. Time (ms) between re-creating the socket. Defaults to `1000`.
 
 ### StatsD methods
 All StatsD methods other than `event`, `close`, and `check` have the same API:

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -154,6 +154,45 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
     global.statsd = this;
   }
 
+  // only for uds (options.protocol uds)
+  // enabled with the extra flag options.udsGracefulErrorHandling
+  // will gracefully (attempt) to re-open the socket with a small delay
+  // options.udsGracefulRestartRateLimit is the minimum time (ms) between creating sockets
+  // does not support options.isChild (how to re-create a socket you didn't create?)
+  if (!options.isChild && options.protocol === 'uds' && options.udsGracefulErrorHandling) {
+    const socketCreateLimit = options.udsGracefulRestartRateLimit || 1000; // only recreate once per second
+    const lastSocketCreateTime = Date.now();
+    this.socket.on('error', (err) => {
+      const code = err.code;
+      switch (code) {
+        case 107:
+        case 111: {
+          if (Date.now() - lastSocketCreateTime >= socketCreateLimit) {
+            // recreate the socket, but only once per 30 seconds
+            if (this.errorHandler) {
+              this.socket.removeListener('error', this.errorHandler);
+            }
+            this.socket.close();
+            this.socket = createSocket(this, {
+              host: this.host,
+              path: options.path,
+              port: this.port,
+              protocol: this.protocol
+            });
+
+            if (this.errorHandler) {
+              this.socket.on('error', this.errorHandler);
+            }
+          }
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+  }
+
   if (options.useDefaultRoute) {
     const defaultRoute = helpers.getDefaultRoute();
     if (defaultRoute) {

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -50,123 +50,6 @@ describe('#errorHandling', () => {
     });
   });
 
-  it('should re-create the socket on 111 error for type uds', (done) => {
-    const code = 111;
-    const realDateNow = Date.now;
-    console.log(Date.now, realDateNow);
-    Date.now = () => '4857394578';
-    // emit an error, like a socket would
-    // 111 is connection refused
-    server = createServer('uds_broken', address => {
-      const client = statsd = createHotShotsClient({
-        host: address.address,
-        port: address.port,
-        protocol: 'uds',
-        udsGracefulErrorHandling: true,
-        errorHandler(error) {
-          assert.ok(error);
-          assert.equal(error.code, code);
-        }
-      }, 'client');
-      const initialSocket = client.socket;
-      setTimeout(() => {
-        initialSocket.emit('error', { code });
-        assert.ok(Object.is(initialSocket, client.socket));
-        // it should not create the socket if it breaks too quickly
-        // change time and make another error
-        Date.now = () => 4857394578 + 1000; // 1 second later
-        initialSocket.emit('error', { code });
-        setTimeout(() => {
-          // make sure the socket was re-created
-          assert.notEqual(initialSocket, client.socket);
-          // put things back
-          Date.now = realDateNow;
-          done();
-        }, 5);
-      }, 5);
-    });
-  });
-
-  it('should re-create the socket on 107 error for type uds', (done) => {
-    const code = 107;
-    const realDateNow = Date.now;
-    Date.now = () => '4857394578';
-    // emit an error, like a socket would
-    // 111 is connection refused
-    server = createServer('uds_broken', address => {
-      const client = statsd = createHotShotsClient({
-        host: address.address,
-        port: address.port,
-        protocol: 'uds',
-        udsGracefulErrorHandling: true,
-        errorHandler(error) {
-          assert.ok(error);
-          assert.equal(error.code, code);
-        }
-      }, 'client');
-      const initialSocket = client.socket;
-      setTimeout(() => {
-        initialSocket.emit('error', { code });
-        assert.ok(Object.is(initialSocket, client.socket));
-        // it should not create the socket if it breaks too quickly
-        // change time and make another error
-        Date.now = () => 4857394578 + 1000; // 1 second later
-        initialSocket.emit('error', { code });
-        setTimeout(() => {
-          // make sure the socket was re-created
-          assert.notEqual(initialSocket, client.socket);
-          // put things back
-          Date.now = realDateNow;
-          done();
-        }, 5);
-      }, 5);
-    });
-  });
-
-  it('should re-create the socket on error for type uds with the configurable limit', (done) => {
-    const code = 111;
-    const limit = 4000;
-    const realDateNow = Date.now;
-    Date.now = () => '4857394578';
-    // emit an error, like a socket would
-    // 111 is connection refused
-    server = createServer('uds_broken', address => {
-      const client = statsd = createHotShotsClient({
-        host: address.address,
-        port: address.port,
-        protocol: 'uds',
-        udsGracefulErrorHandling: true,
-        udsGracefulRestartRateLimit: limit,
-        errorHandler(error) {
-          assert.ok(error);
-          assert.equal(error.code, code);
-        }
-      }, 'client');
-      const initialSocket = client.socket;
-      setTimeout(() => {
-        initialSocket.emit('error', { code });
-        assert.ok(Object.is(initialSocket, client.socket));
-        // it should not create the socket if it breaks too quickly
-        // change time and make another error
-        Date.now = () => 4857394578 + 1000; // 1 second later
-        initialSocket.emit('error', { code });
-        setTimeout(() => {
-          // make sure the socket was NOT re-created
-          assert.equal(initialSocket, client.socket);
-          Date.now = () => 4857394578 + limit; // 1 second later
-          initialSocket.emit('error', { code });
-          setTimeout(() => {
-            // make sure the socket was re-created
-            assert.notEqual(initialSocket, client.socket);
-            // put things back
-            Date.now = realDateNow;
-            done();
-          }, 5);
-        }, 5);
-      }, 5);
-    });
-  });
-
   testTypes().forEach(([description, serverType, clientType]) => {
     describe(description, () => {
       it('should not use errorHandler when there is not an error', done => {
@@ -297,6 +180,125 @@ describe('#errorHandling', () => {
 
         statsd.send('test title');
       });
+
+      if (serverType === 'uds' && clientType === 'client') {
+        it('should re-create the socket on 111 error for type uds', (done) => {
+          const code = 111;
+          const realDateNow = Date.now;
+          console.log(Date.now, realDateNow);
+          Date.now = () => '4857394578';
+          // emit an error, like a socket would
+          // 111 is connection refused
+          server = createServer('uds_broken', address => {
+            const client = statsd = createHotShotsClient({
+              host: address.address,
+              port: address.port,
+              protocol: 'uds',
+              udsGracefulErrorHandling: true,
+              errorHandler(error) {
+                assert.ok(error);
+                assert.equal(error.code, code);
+              }
+            }, 'client');
+            const initialSocket = client.socket;
+            setTimeout(() => {
+              initialSocket.emit('error', { code });
+              assert.ok(Object.is(initialSocket, client.socket));
+              // it should not create the socket if it breaks too quickly
+              // change time and make another error
+              Date.now = () => 4857394578 + 1000; // 1 second later
+              initialSocket.emit('error', { code });
+              setTimeout(() => {
+                // make sure the socket was re-created
+                assert.notEqual(initialSocket, client.socket);
+                // put things back
+                Date.now = realDateNow;
+                done();
+              }, 5);
+            }, 5);
+          });
+        });
+
+        it('should re-create the socket on 107 error for type uds', (done) => {
+          const code = 107;
+          const realDateNow = Date.now;
+          Date.now = () => '4857394578';
+          // emit an error, like a socket would
+          // 111 is connection refused
+          server = createServer('uds_broken', address => {
+            const client = statsd = createHotShotsClient({
+              host: address.address,
+              port: address.port,
+              protocol: 'uds',
+              udsGracefulErrorHandling: true,
+              errorHandler(error) {
+                assert.ok(error);
+                assert.equal(error.code, code);
+              }
+            }, 'client');
+            const initialSocket = client.socket;
+            setTimeout(() => {
+              initialSocket.emit('error', { code });
+              assert.ok(Object.is(initialSocket, client.socket));
+              // it should not create the socket if it breaks too quickly
+              // change time and make another error
+              Date.now = () => 4857394578 + 1000; // 1 second later
+              initialSocket.emit('error', { code });
+              setTimeout(() => {
+                // make sure the socket was re-created
+                assert.notEqual(initialSocket, client.socket);
+                // put things back
+                Date.now = realDateNow;
+                done();
+              }, 5);
+            }, 5);
+          });
+        });
+
+        it('should re-create the socket on error for type uds with the configurable limit', (done) => {
+          const code = 111;
+          const limit = 4000;
+          const realDateNow = Date.now;
+          Date.now = () => '4857394578';
+          // emit an error, like a socket would
+          // 111 is connection refused
+          server = createServer('uds_broken', address => {
+            const client = statsd = createHotShotsClient({
+              host: address.address,
+              port: address.port,
+              protocol: 'uds',
+              udsGracefulErrorHandling: true,
+              udsGracefulRestartRateLimit: limit,
+              errorHandler(error) {
+                assert.ok(error);
+                assert.equal(error.code, code);
+              }
+            }, 'client');
+            const initialSocket = client.socket;
+            setTimeout(() => {
+              initialSocket.emit('error', { code });
+              assert.ok(Object.is(initialSocket, client.socket));
+              // it should not create the socket if it breaks too quickly
+              // change time and make another error
+              Date.now = () => 4857394578 + 1000; // 1 second later
+              initialSocket.emit('error', { code });
+              setTimeout(() => {
+                // make sure the socket was NOT re-created
+                assert.equal(initialSocket, client.socket);
+                Date.now = () => 4857394578 + limit; // 1 second later
+                initialSocket.emit('error', { code });
+                setTimeout(() => {
+                  // make sure the socket was re-created
+                  assert.notEqual(initialSocket, client.socket);
+                  // put things back
+                  Date.now = realDateNow;
+                  done();
+                }, 5);
+              }, 5);
+            }, 5);
+          });
+        });
+      }
     });
   });
 });

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -185,7 +185,6 @@ describe('#errorHandling', () => {
         it('should re-create the socket on 111 error for type uds', (done) => {
           const code = 111;
           const realDateNow = Date.now;
-          console.log(Date.now, realDateNow);
           Date.now = () => '4857394578';
           // emit an error, like a socket would
           // 111 is connection refused


### PR DESCRIPTION
…a time limit

An attempt at solving the problem mentioned in brightcove/hot-shots#114


things to note:
- this solution ignores non-uds protocols
- it is off by default
- it adds two new options
  - udsGracefulErrorHandling (boolean) enable/disable this new func (default = disable)
  - udsGracefulRestartRateLimit (int) time (ms) between creating a new socket (prevents wild thrashing)