### PR TITLE
Fix cacheDns option when obtaining host from DD_AGENT_HOST

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -137,7 +137,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       this.dnsError = options.dnsError;
     }
   } else if (options.cacheDns === true) {
-    dns.lookup(options.host, (err, address) => {
+    dns.lookup(this.host, (err, address) => {
       if (err === null) {
         self.host = address;
       } else {

--- a/test/init.js
+++ b/test/init.js
@@ -166,6 +166,24 @@ describe('#init', () => {
     statsd = createHotShotsClient({ host: 'localhost', cacheDns: true }, clientType);
   });
 
+  it('should attempt to cache a dns record if dnsCache is specified and DD_AGENT_HOST is set', done => {
+    const originalLookup = dns.lookup;
+
+    // Replace the dns lookup function with our mock dns lookup
+    dns.lookup = (host, callback) => {
+      process.nextTick(() => {
+        dns.lookup = originalLookup;
+        assert.equal(statsd.host, host);
+        callback(null, '127.0.0.1', 4);
+        assert.equal(statsd.host, '127.0.0.1');
+        done();
+      });
+    };
+
+    process.env.DD_AGENT_HOST = 'localhost';
+    statsd = createHotShotsClient({ cacheDns: true }, clientType);
+  });
+
   it('should not attempt to cache a dns record if dnsCache is not specified', done => {
     const originalLookup = dns.lookup;
 


### PR DESCRIPTION
Look up `this.host`, not `options.host`, so that caching works when the host is obtained from the `DD_AGENT_HOST` environment variable or the default value of `"localhost"` is used. `this.host` is initialized with `options.host || process.env.DD_AGENT_HOST || 'localhost'`.