### PR TITLE
Fix crasher when closing Unix Datagram Sockets without callback

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -490,7 +490,9 @@ Client.prototype._close = function (callback) {
       this.socket.close();
       // this close is synchronous, and the socket will not emit a
       // close event, so we can callback right away
-      callback();
+      if (callback) {
+        callback();
+      }
     }
     else {
       this.socket.close();


### PR DESCRIPTION
```javascript
const statsd = new hotShots.Client({type: 'uds'});
uds.close(function () {}); // works fine
uds.close(); // TypeError: callback is not a function
```

Elsewhere in `close()`, the existence of callback is checked a lot, so I assume this to be an oversight.