### PR TITLE
override host before socket created by createTransport

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -41,6 +41,14 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   // hidden global_tags option for backwards compatibility
   options.globalTags = options.globalTags || options.global_tags;
 
+  if (options.useDefaultRoute) {
+    const defaultRoute = helpers.getDefaultRoute();
+    if (defaultRoute) {
+      console.log(`Got ${defaultRoute} for the system's default route`);
+      this.host = defaultRoute;
+    }
+  }
+
   this.protocol = (options.protocol && options.protocol.toLowerCase());
   this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
@@ -141,14 +149,6 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
         }
       }
     });
-  }
-
-  if (options.useDefaultRoute) {
-    const defaultRoute = helpers.getDefaultRoute();
-    if (defaultRoute) {
-      console.log(`Got ${defaultRoute} for the system's default route`);
-      this.host = defaultRoute;
-    }
   }
 
   this.messagesInFlight = 0;

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -41,6 +41,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   // hidden global_tags option for backwards compatibility
   options.globalTags = options.globalTags || options.global_tags;
 
+  this.protocol = (options.protocol && options.protocol.toLowerCase());
+  this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
   if (options.useDefaultRoute) {
     const defaultRoute = helpers.getDefaultRoute();
     if (defaultRoute) {
@@ -48,9 +50,6 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       this.host = defaultRoute;
     }
   }
-
-  this.protocol = (options.protocol && options.protocol.toLowerCase());
-  this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix = options.prefix || '';
   this.suffix = options.suffix || '';

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -43,23 +43,9 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
 
   this.protocol = (options.protocol && options.protocol.toLowerCase());
   this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
-  if (options.useDefaultRoute) {
-    const defaultRoute = helpers.getDefaultRoute();
-    if (defaultRoute) {
-      console.log(`Got ${defaultRoute} for the system's default route`);
-      this.host = defaultRoute;
-    }
-  }
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix = options.prefix || '';
   this.suffix = options.suffix || '';
-  this.socket = options.isChild ? options.socket : createTransport(this, {
-    host: this.host,
-    path: options.path,
-    port: this.port,
-    protocol: this.protocol,
-    stream: options.stream
-  });
   this.mock        = options.mock;
   this.globalTags  = typeof options.globalTags === 'object' ?
       helpers.formatTags(options.globalTags, options.telegraf) : [];
@@ -100,6 +86,22 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       }
     });
   }
+
+  if (options.useDefaultRoute) {
+    const defaultRoute = helpers.getDefaultRoute();
+    if (defaultRoute) {
+      console.log(`Got ${defaultRoute} for the system's default route`);
+      this.host = defaultRoute;
+    }
+  }
+
+  this.socket = options.isChild ? options.socket : createTransport(this, {
+    host: this.host,
+    path: options.path,
+    port: this.port,
+    protocol: this.protocol,
+    stream: options.stream
+  });
 
   if (!options.isChild && options.errorHandler) {
     this.socket.on('error', options.errorHandler);
@@ -149,6 +151,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       }
     });
   }
+
 
   this.messagesInFlight = 0;
   this.CHECKS = {


### PR DESCRIPTION
As per https://github.com/brightcove/hot-shots/issues/136

The `useDefaultRoute` was being handled after the `host` is being used for `createTransport`.

This PR is to move the `useDefaultRoute` above to override the `this.host` before it is being used. Also move the `this.socket` init after all the `host` override so that the `cacheDns` will work as well.