### PR TITLE
Fix StatsD typings

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -132,5 +132,5 @@ declare module "hot-shots" {
   }
 }
 
-declare const StatsDClient: StatsD;
+declare const StatsDClient: new (options?: ClientOptions) => StatsD;
 export default StatsDClient;


### PR DESCRIPTION
As per #140 changed the `export class StatsD`  to be an interface.