### PR TITLE
Fix missing host update

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -103,7 +103,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       if (err === null) {
         this.host = address;
         // update for uds to use for each send call
-        this.socket.setHost = this.host;
+        this.socket.updateHost(this.host);
       } else {
         this.dnsError = err;
       }


### PR DESCRIPTION
Recent fixes for DNS cache did not help because the host has not been properly updated. This fix was tested with tcpdump.