### PR TITLE
Don't send undefined as a value

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -197,6 +197,13 @@ Client.prototype.sendAll = function (stat, value, type, sampleRate, tags, callba
     tags = undefined;
   }
 
+  if (value === undefined) {
+    if (typeof callback === 'function') {
+      callback(null, 0);
+    }
+    return;
+  }
+
   /**
    * Gets called once for each callback, when all callbacks return we will
    * call back from the function


### PR DESCRIPTION
I'm not really sure that this should be part of this repository, so I'll leave that up to you. The problem is that when you send `undefined` as a value, statsd will not store anything and hence it received redundant message which had to be processed and it will generate error in the log:
```
2020-03-06T09:56:29.199975+00:00 statsd1 statsd[30923]: Bad line: undefined,g in msg "servers.app03.application.4d2a665c-5ed0-11ea-826a-06cd01d45cce.io_read:undefined|g"
```