### PR TITLE
Enables a configurable time-to-live for dns lookups for UDP transport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Parameters (specified as one object passed into hot-shots):
 * `prefix`:      What to prefix each stat name with `default: ''`
 * `suffix`:      What to suffix each stat name with `default: ''`
 * `globalize`:   Expose this StatsD instance globally. `default: false`
-* `cacheDns`:    Cache the initial dns lookup to *host* , only used
-  when protocol is `uds`, `default: false`
+* `cacheDns`:    Caches dns lookup to *host* for *dnsTtlMilliseconds*, only used
+  when protocol is `udp`, `default: false`
+* `dnsTtlMilliseconds`: time-to-live of dns lookups in milliseconds, when *cacheDns* is enabled. `default: 60000`
 * `mock`:        Create a mock StatsD instance, sending no stats to
   the server and allowing data to be read from mockBuffer.  Note that
   mockBuffer will keep growing, so only use for testing or clear out periodically. `default: false`

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Parameters (specified as one object passed into hot-shots):
 * `prefix`:      What to prefix each stat name with `default: ''`
 * `suffix`:      What to suffix each stat name with `default: ''`
 * `globalize`:   Expose this StatsD instance globally. `default: false`
-* `cacheDns`:    Caches dns lookup to *host* for *dnsTtlMilliseconds*, only used
+* `cacheDns`:    Caches dns lookup to *host* for *cacheDnsTtl*, only used
   when protocol is `udp`, `default: false`
-* `dnsTtlMilliseconds`: time-to-live of dns lookups in milliseconds, when *cacheDns* is enabled. `default: 60000`
+* `cacheDnsTtl`: time-to-live of dns lookups in milliseconds, when *cacheDns* is enabled. `default: 60000`
 * `mock`:        Create a mock StatsD instance, sending no stats to
   the server and allowing data to be read from mockBuffer.  Note that
   mockBuffer will keep growing, so only use for testing or clear out periodically. `default: false`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,5 +1,4 @@
 const util = require('util'),
-  dns = require('dns'),
   helpers = require('./helpers'),
   applyStatsFns = require('./statsFunctions');
 
@@ -44,6 +43,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   if (! this.protocol) {
     this.protocol = PROTOCOL.UDP;
   }
+  this.cacheDns = options.cacheDns === true;
+  this.dnsTtlMilliseconds = options.dnsTtlMilliseconds || 60000;
   this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix = options.prefix || '';
@@ -91,22 +92,12 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   if (! this.socket) {
     this.socket = createTransport(this, {
       host: this.host,
+      cacheDns: this.cacheDns,
+      dnsTtlMilliseconds: this.dnsTtlMilliseconds,
       path: options.path,
       port: this.port,
       protocol: this.protocol,
       stream: options.stream
-    });
-  }
-
-  if (options.cacheDns === true && this.protocol === PROTOCOL.UDP) {
-    dns.lookup(this.host, (err, address) => {
-      if (err === null) {
-        this.host = address;
-        // update for uds to use for each send call
-        this.socket.updateHost(this.host);
-      } else {
-        this.dnsError = err;
-      }
     });
   }
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -6,6 +6,7 @@ const { PROTOCOL } = require('./constants');
 const createTransport = require('./transport');
 
 const UDS_DEFAULT_GRACEFUL_RESTART_LIMIT = 1000;
+const CACHE_DNS_TTL_DEFAULT = 60000;
 
 /**
  * The Client for StatsD.  The main entry-point for hot-shots.  Note adding new parameters
@@ -44,7 +45,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
     this.protocol = PROTOCOL.UDP;
   }
   this.cacheDns = options.cacheDns === true;
-  this.dnsTtlMilliseconds = options.dnsTtlMilliseconds || 60000;
+  this.cacheDnsTtl = options.cacheDnsTtl || CACHE_DNS_TTL_DEFAULT;
   this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix = options.prefix || '';
@@ -93,7 +94,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
     this.socket = createTransport(this, {
       host: this.host,
       cacheDns: this.cacheDns,
-      dnsTtlMilliseconds: this.dnsTtlMilliseconds,
+      cacheDnsTtl: this.cacheDnsTtl,
       path: options.path,
       port: this.port,
       protocol: this.protocol,

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const dgram = require('dgram');
 const net = require('net');
+const dns = require('dns');
 const { PROTOCOL } = require('./constants');
 
 // Imported below, only if needed
@@ -42,12 +43,39 @@ const createTcpTransport = args => {
 
 const createUdpTransport = args => {
   const socket = dgram.createSocket('udp4');
+  const dnsResolutionData = {
+    timestamp: new Date(0),
+    resolvedAddress: undefined
+  };
+
+  const sendUsingDnsCache = (callback, buf) => {
+    const now = new Date();
+    if (dnsResolutionData.resolvedAddress === undefined || (now - dnsResolutionData.timestamp > args.dnsTtlMilliseconds)) {
+      dns.lookup(args.host, (error, address) => {
+        if (error) {
+          callback(error);
+          return;
+        }
+        dnsResolutionData.resolvedAddress = address;
+        socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
+      });
+    } else {
+      socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
+    }
+    dnsResolutionData.timestamp = now;
+  };
+
   return {
-    updateHost: (newHost) => { args.host = newHost; },
     emit: socket.emit.bind(socket),
     on: socket.on.bind(socket),
     removeListener: socket.removeListener.bind(socket),
-    send: (buf, callback) => socket.send(buf, 0, buf.length, args.port, args.host, callback),
+    send: function (buf, callback) {
+      if (args.cacheDns) {
+        sendUsingDnsCache(callback, buf);
+      } else {
+        socket.send(buf, 0, buf.length, args.port, args.host, callback);
+      }
+    },
     close: socket.close.bind(socket),
     unref: socket.unref.bind(socket)
   };

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -50,7 +50,7 @@ const createUdpTransport = args => {
 
   const sendUsingDnsCache = (callback, buf) => {
     const now = new Date();
-    if (dnsResolutionData.resolvedAddress === undefined || (now - dnsResolutionData.timestamp > args.dnsTtlMilliseconds)) {
+    if (dnsResolutionData.resolvedAddress === undefined || (now - dnsResolutionData.timestamp > args.cacheDnsTtl)) {
       dns.lookup(args.host, (error, address) => {
         if (error) {
           callback(error);

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -57,12 +57,12 @@ const createUdpTransport = args => {
           return;
         }
         dnsResolutionData.resolvedAddress = address;
+        dnsResolutionData.timestamp = now;
         socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
       });
     } else {
       socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
     }
-    dnsResolutionData.timestamp = now;
   };
 
   return {

--- a/test/init.js
+++ b/test/init.js
@@ -147,41 +147,6 @@ describe('#init', () => {
     assert.deepEqual(statsd.globalTags, ['gtag', 'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
   });
 
-  it('should lookup a dns record if dnsCache is specified', done => {
-    const originalLookup = dns.lookup;
-
-    // Replace the dns lookup function with our mock dns lookup
-    dns.lookup = (host, callback) => {
-      process.nextTick(() => {
-        dns.lookup = originalLookup;
-        assert.equal(statsd.host, host);
-        callback(null, '127.0.0.1', 4);
-        assert.equal(statsd.host, '127.0.0.1');
-        done();
-      });
-    };
-
-    statsd = createHotShotsClient({ host: 'localhost', cacheDns: true }, clientType);
-  });
-
-  it('should lookup a dns record if dnsCache is specified and DD_AGENT_HOST is set', done => {
-    const originalLookup = dns.lookup;
-
-    // Replace the dns lookup function with our mock dns lookup
-    dns.lookup = (host, callback) => {
-      process.nextTick(() => {
-        dns.lookup = originalLookup;
-        assert.equal(statsd.host, host);
-        callback(null, '127.0.0.1', 4);
-        assert.equal(statsd.host, '127.0.0.1');
-        done();
-      });
-    };
-
-    process.env.DD_AGENT_HOST = 'localhost';
-    statsd = createHotShotsClient({ cacheDns: true }, clientType);
-  });
-
   it('should not lookup a dns record if dnsCache is not specified', done => {
     const originalLookup = dns.lookup;
 
@@ -209,7 +174,7 @@ describe('#init', () => {
     statsd = createHotShotsClient({ host: 'localhost', cacheDns: true }, clientType);
 
     statsd.increment('test', 1, 1, null, err => {
-      assert.equal(err.message, 'Bad host');
+      assert.equal(err.message, 'Error sending hot-shots message: Error: Bad host');
       dns.lookup = originalLookup;
       done();
     });

--- a/test/udpDnsCacheTransport.js
+++ b/test/udpDnsCacheTransport.js
@@ -1,0 +1,158 @@
+const assert = require('assert');
+const helpers = require('./helpers/helpers.js');
+const dns = require('dns');
+const dgram = require('dgram');
+
+const closeAll = helpers.closeAll;
+const createServer = helpers.createServer;
+const createHotShotsClient = helpers.createHotShotsClient;
+
+/**
+ * Socket mock constructor.
+ * @constructor
+ */
+function SocketMock() {
+  // eslint-disable-next-line no-empty-function
+  this.emit = { bind: () => {} };
+  // eslint-disable-next-line no-empty-function
+  this.on = () => { return { bind: () => {} }; };
+  // eslint-disable-next-line no-empty-function
+  this.removeListener = { bind: () => {} };
+  // eslint-disable-next-line no-empty-function
+  this.close = { bind: () => {} };
+  // eslint-disable-next-line no-empty-function
+  this.unref = { bind: () => {} };
+  this.sendCount = 0;
+  this.send = (buf, offset, length, port, host, callback) => {
+    this.buf = buf;
+    this.offset = offset;
+    this.length = length;
+    this.port = port;
+    this.host = host;
+    this.sendCount++;
+    callback();
+  };
+}
+
+const mockDgramSocket = () => {
+  const socketMock = new SocketMock();
+  dgram.createSocket = () => socketMock;
+  return socketMock;
+};
+
+describe('#udpDnsCacheTransport', () => {
+  const udpServerType = 'udp';
+  const originalDnsLookup = dns.lookup;
+  const originalDgramCreateSocket = dgram.createSocket;
+  let server;
+  let statsd;
+
+  afterEach(done => {
+    dns.lookup = originalDnsLookup;
+    dgram.createSocket = originalDgramCreateSocket;
+    closeAll(server, statsd, false, done);
+  });
+
+  describe('Sending first message', () => {
+    it('should lookup dns once', done => {
+      server = createServer(udpServerType, opts => {
+        const socketMock = mockDgramSocket();
+
+        statsd = createHotShotsClient(Object.assign(opts, {
+          cacheDns: true
+        }), 'client');
+
+        const resolvedHostAddress = '1.1.1.1';
+        let dnsLookupCount = 0;
+        dns.lookup = (host, callback) => {
+          dnsLookupCount++;
+          callback(undefined, resolvedHostAddress);
+        };
+
+        statsd.send('test title', {}, (error) => {
+          assert.equal(error, undefined);
+          setTimeout(() => {
+            assert.equal(dnsLookupCount, 1);
+            assert.equal(socketMock.sendCount, 1);
+            assert.equal(socketMock.host, resolvedHostAddress);
+            assert.equal(socketMock.buf, 'test title');
+            done();
+          }, 1000);
+        });
+      });
+    });
+  });
+
+  describe('Sending messages within TTL', () => {
+    it('should lookup dns once', done => {
+      server = createServer(udpServerType, opts => {
+        const socketMock = mockDgramSocket();
+
+        statsd = createHotShotsClient(Object.assign(opts, {
+          cacheDns: true
+        }), 'client');
+
+        const resolvedHostAddress = '1.1.1.1';
+        let dnsLookupCount = 0;
+        dns.lookup = (host, callback) => {
+          callback(undefined, resolvedHostAddress);
+          dnsLookupCount++;
+        };
+
+        statsd.send('message', {}, (error) => {
+          assert.equal(error, undefined);
+        });
+
+        statsd.send('other message', {}, (error) => {
+          assert.equal(error, undefined);
+          setTimeout(() => {
+            assert.equal(dnsLookupCount, 1);
+            assert.equal(socketMock.sendCount, 2);
+            assert.equal(socketMock.host, resolvedHostAddress);
+            done();
+          }, 1000);
+        });
+      });
+    });
+  });
+
+  describe('Sending messages after TTL expired', () => {
+    it('should lookup dns twice', done => {
+      server = createServer(udpServerType, opts => {
+        const socketMock = mockDgramSocket();
+
+        const dnsTtlMilliseconds = 100;
+        statsd = createHotShotsClient(Object.assign(opts, {
+          cacheDns: true,
+          dnsTtlMilliseconds: dnsTtlMilliseconds
+        }), 'client');
+
+        const resolvedHostAddress = '1.1.1.1';
+        let dnsLookupCount = 0;
+        dns.lookup = (host, callback) => {
+          callback(undefined, resolvedHostAddress);
+          dnsLookupCount++;
+        };
+
+        statsd.send('message', {}, (error) => {
+          assert.equal(error, undefined);
+        });
+
+        statsd.send('other message', {}, (error) => {
+          assert.equal(error, undefined);
+        });
+
+        setTimeout(() => {
+          statsd.send('message 1ms after TTL', {}, (error) => {
+            assert.equal(error, undefined);
+            setTimeout(() => {
+              assert.equal(dnsLookupCount, 2);
+              assert.equal(socketMock.sendCount, 3);
+              done();
+            }, 1000);
+          });
+        }, dnsTtlMilliseconds + 1);
+      });
+    });
+  });
+});

--- a/test/udpDnsCacheTransport.js
+++ b/test/udpDnsCacheTransport.js
@@ -121,10 +121,10 @@ describe('#udpDnsCacheTransport', () => {
       server = createServer(udpServerType, opts => {
         const socketMock = mockDgramSocket();
 
-        const dnsTtlMilliseconds = 100;
+        const cacheDnsTtl = 100;
         statsd = createHotShotsClient(Object.assign(opts, {
           cacheDns: true,
-          dnsTtlMilliseconds: dnsTtlMilliseconds
+          cacheDnsTtl: cacheDnsTtl
         }), 'client');
 
         const resolvedHostAddress = '1.1.1.1';
@@ -151,7 +151,7 @@ describe('#udpDnsCacheTransport', () => {
               done();
             }, 1000);
           });
-        }, dnsTtlMilliseconds + 1);
+        }, cacheDnsTtl + 1);
       });
     });
   });

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,6 +6,7 @@ declare module "hot-shots" {
     bufferFlushInterval?: number;
     bufferHolder?: { buffer: string };
     cacheDns?: boolean;
+    dnsTtlMilliseconds?: number;
     errorHandler?: (err: Error) => void;
     globalTags?: Tags;
     globalize?: boolean;

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,7 +6,7 @@ declare module "hot-shots" {
     bufferFlushInterval?: number;
     bufferHolder?: { buffer: string };
     cacheDns?: boolean;
-    dnsTtlMilliseconds?: number;
+    cacheDnsTtl?: number;
     errorHandler?: (err: Error) => void;
     globalTags?: Tags;
     globalize?: boolean;


### PR DESCRIPTION
Hello,

Currently, when `cacheDns` is enabled, you'll have a single lookup when the client is created. The risk (which depending on your environment will happen sooner or later) is losing metrics when the target host changes the IP for whatever reason.

There is already an issue for this: https://github.com/brightcove/hot-shots/issues/104

This PR enables a TTL for dns lookups with `60s` as the default. 
Please consider if the changes are ok and let me know if you would like any changes.

Best regards!
