### PR TITLE
Tag prefix separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Parameters (specified as one object passed into hot-shots):
 * `port`:        The port to send stats to, if not set, the constructor tries to retrieve it from the `DD_DOGSTATSD_PORT` environment variable, `default: 8125`
 * `prefix`:      What to prefix each stat name with `default: ''`
 * `suffix`:      What to suffix each stat name with `default: ''`
-* `tagPrefix`:   Prefix tag list with character `default: '~'`. Note does not work with `telegraf` option.
+* `tagPrefix`:   Prefix tag list with character `default: '#'`. Note does not work with `telegraf` option.
 * `tagSeparator`: Separate tags with character `default: ','`. Note does not work with `telegraf` option.
 * `globalize`:   Expose this StatsD instance globally. `default: false`
 * `cacheDns`:    Caches dns lookup to *host* for *cacheDnsTtl*, only used

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Parameters (specified as one object passed into hot-shots):
 * `port`:        The port to send stats to, if not set, the constructor tries to retrieve it from the `DD_DOGSTATSD_PORT` environment variable, `default: 8125`
 * `prefix`:      What to prefix each stat name with `default: ''`
 * `suffix`:      What to suffix each stat name with `default: ''`
+* `tagPrefix`:   Prefix tag list with character `default: '~'`. Note does not work with `telegraf` option.
+* `tagSeparator`: Separate tags with character `default: ','`. Note does not work with `telegraf` option.
 * `globalize`:   Expose this StatsD instance globally. `default: false`
 * `cacheDns`:    Caches dns lookup to *host* for *cacheDnsTtl*, only used
   when protocol is `udp`, `default: false`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -50,6 +50,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix = options.prefix || '';
   this.suffix = options.suffix || '';
+  this.tagPrefix = options.tagPrefix || '#';
+  this.tagSeparator = options.tagSeparator || ',';
   this.mock        = options.mock;
   this.globalTags  = typeof options.globalTags === 'object' ?
       helpers.formatTags(options.globalTags, options.telegraf) : [];
@@ -268,7 +270,7 @@ Client.prototype.send = function (message, tags, callback) {
       message = message.split(':');
       message = `${message[0]},${mergedTags.join(',').replace(/:/g, '=')}:${message.slice(1).join(':')}`;
     } else {
-      message += `|#${mergedTags.join(',')}`;
+      message += `|${this.tagPrefix}${mergedTags.join(this.tagSeparator)}`;
     }
   }
 
@@ -490,6 +492,8 @@ const ChildClient = function (parent, options) {
     errorHandler: options.errorHandler || parent.errorHandler, // Handler for callback errors
     host        : parent.host,
     port        : parent.port,
+    tagPrefix   : parent.tagPrefix,
+    tagSeparator : parent.tagSeparator,
     prefix      : (options.prefix || '') + parent.prefix, // Child has its prefix prepended to parent's prefix
     suffix      : parent.suffix + (options.suffix || ''), // Child has its suffix appended to parent's suffix
     globalize   : false, // Only 'root' client can be global

--- a/test/globalTags.js
+++ b/test/globalTags.js
@@ -96,6 +96,49 @@ describe('#globalTags', () => {
         });
       });
 
+      it('should format tags using prefix', done => {
+        server = createServer(serverType, opts => {
+          statsd = createHotShotsClient(Object.assign(opts, {
+            globalTags: { gtag: '123', foo: 'bar' },
+            tagPrefix: '~',
+          }), clientType);
+          statsd.increment('test', 1337, { gtag: '234' });
+        });
+        server.on('metrics', metrics => {
+          assert.equal(metrics, `test:1337|c|~gtag:234,foo:bar${metricEnd}`);
+          done();
+        });
+      });
+
+      it('should format tags using separator', done => {
+        server = createServer(serverType, opts => {
+          statsd = createHotShotsClient(Object.assign(opts, {
+            globalTags: { gtag: '123', foo: 'bar' },
+            tagSeparator: '~',
+          }), clientType);
+          statsd.increment('test', 1337, { gtag: '234' });
+        });
+        server.on('metrics', metrics => {
+          assert.equal(metrics, `test:1337|c|#gtag:234~foo:bar${metricEnd}`);
+          done();
+        });
+      });
+
+      it('should format tags using prefix & separator', done => {
+        server = createServer(serverType, opts => {
+          statsd = createHotShotsClient(Object.assign(opts, {
+            globalTags: { gtag: '123', foo: 'bar' },
+            tagPrefix: '~',
+            tagSeparator: '~',
+          }), clientType);
+          statsd.increment('test', 1337, { gtag: '234' });
+        });
+        server.on('metrics', metrics => {
+          assert.equal(metrics, `test:1337|c|~gtag:234~foo:bar${metricEnd}`);
+          done();
+        });
+      });
+
       it('should replace reserved characters with underscores in tags', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {

--- a/types.d.ts
+++ b/types.d.ts
@@ -23,6 +23,8 @@ declare module "hot-shots" {
     suffix?: string;
     telegraf?: boolean;
     useDefaultRoute?: boolean;
+    tagPrefix?: string;
+    tagSeparator?: string;
   }
 
   export interface ChildClientOptions {


### PR DESCRIPTION
Hello! Big fan of the library but we've been struggling to use it to it's fullest because of some idiosyncrasies of our statsd format, particularly with tags. In our case it can be addressed by allowing control over the characters used to separate tags:

```
* `tagPrefix`:   Prefix tag list with character `default: '#'`. Note does not work with `telegraf` option.
* `tagSeparator`: Separate tags with character `default: ','`. Note does not work with `telegraf` option.
```

I implemented this in a fork for my own use, but wanted to see if there was any interest in using it. Cheers!