### PR TITLE
Add UDS graceful error handling options to typescript

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -23,6 +23,8 @@ declare module "hot-shots" {
     suffix?: string;
     telegraf?: boolean;
     useDefaultRoute?: boolean;
+    udsGracefulErrorHandling?: boolean;
+    udsGracefulRestartRateLimit?: number;
   }
 
   export interface ChildClientOptions {


### PR DESCRIPTION
This PR adds the two missing options, `udsGracefulErrorHandling` and `udsGracefulRestartRateLimit `, for graceful error handling to the `ClientOptions` typescript interface.