### PR TITLE
Create Mock Transport

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -100,7 +100,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
       path: options.path,
       port: this.port,
       protocol: this.protocol,
-      stream: options.stream
+      stream: options.stream,
+      mock: this.mock
     });
   }
 
@@ -135,7 +136,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
               host: this.host,
               path: options.path,
               port: this.port,
-              protocol: this.protocol
+              protocol: this.protocol,
+              mock: this.mock
             });
 
             if (this.errorHandler) {
@@ -294,18 +296,14 @@ Client.prototype._send = function (message, callback) {
     throw this.dnsError;
   }
 
-  // Only send this stat if we're not a mock Client.
-  if (!this.mock) {
-    if (this.maxBufferSize === 0) {
-      this.sendMessage(message, callback);
-    } else {
-      this.enqueue(message, callback);
-    }
-  } else {
+  if (this.mock) {
     this.mockBuffer.push(message);
-    if (typeof callback === 'function') {
-      callback(null, 0);
-    }
+  }
+
+  if (this.maxBufferSize === 0) {
+    this.sendMessage(message, callback);
+  } else {
+    this.enqueue(message, callback);
   }
 };
 

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -25,6 +25,23 @@ const addEol = (buf) => {
 //   close():void;
 //   unref(): void;
 // }
+const createMockTransport = () => {
+  const buffer = [];
+  return {
+    emit: () => null,
+    on: () => null,
+    removeListener: () => null,
+    send: (buff, callback) => {
+      buffer.push(buff.toString());
+      if (typeof callback === 'function') {
+        callback(null, 0);
+      }
+    },
+    close: (f) => f(),
+    unref: () => null
+  };
+};
+
 const createTcpTransport = args => {
   const socket = net.connect(args.port, args.host);
   socket.setKeepAlive(true);
@@ -139,9 +156,12 @@ const createStreamTransport = (args) => {
 module.exports = (instance, args) => {
   let transport = null;
   const protocol = args.protocol || PROTOCOL.UDP;
+  const mock = args.mock;
 
   try {
-    if (protocol === PROTOCOL.TCP) {
+    if (mock) {
+      transport = createMockTransport(args);
+    } else if (protocol === PROTOCOL.TCP) {
       transport = createTcpTransport(args);
     } else if (protocol === PROTOCOL.UDS) {
       transport = createUdsTransport(args);


### PR DESCRIPTION
Potential solution for issue #92 

Implements a new mock transport with largely no-op functionality. It does maintain a buffer of dispatched messages that could be used to replace the `mockBuffer` currently implemented in the base `statsd`. I haven't yet figured a way of doing this without breaking the current API...