### PR TITLE
Fix types for set/unique

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -115,15 +115,15 @@ declare module "hot-shots" {
     gauge(stat: string | string[], value: number, callback?: StatsCb): void;
     gauge(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
 
-    set(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    set(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    set(stat: string | string[], value: number, callback?: StatsCb): void;
-    set(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+    set(stat: string | string[], value: number | string, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    set(stat: string | string[], value: number | string, tags?: Tags, callback?: StatsCb): void;
+    set(stat: string | string[], value: number | string, callback?: StatsCb): void;
+    set(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
 
-    unique(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number | string, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number | string, tags?: Tags, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number | string, callback?: StatsCb): void;
+    unique(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
 
     close(callback: (error?: Error) => void): void;
 


### PR DESCRIPTION
Value can be a string.

```javascript
// Set: Counts unique occurrences of a stat (alias of unique)
client.set('my_unique', 'foobar');
client.unique('my_unique', 'foobarbaz');
```