### PR TITLE
Fix socket/interval blocking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -227,7 +227,6 @@ module.exports = {
         "prefer-const": "error",
         "prefer-destructuring": "off",
         "prefer-numeric-literals": "error",
-        "prefer-object-spread": "error",
         "prefer-promise-reject-errors": "error",
         "prefer-reflect": "off",
         "prefer-rest-params": "error",

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -77,6 +77,8 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   // We only want a single flush event per parent and all its child clients
   if (!options.isChild && this.maxBufferSize > 0) {
     this.intervalHandle = setInterval(this.onBufferFlushInterval.bind(this), this.bufferFlushInterval);
+    // do not block node from shutting down
+    this.intervalHandle.unref();
   }
 
   if (options.isChild) {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -28,6 +28,8 @@ const addEol = (buf) => {
 const createTcpTransport = args => {
   const socket = net.connect(args.port, args.host);
   socket.setKeepAlive(true);
+  // do not block node from shutting down
+  socket.unref();
   return {
     emit: socket.emit.bind(socket),
     on: socket.on.bind(socket),
@@ -43,6 +45,9 @@ const createTcpTransport = args => {
 
 const createUdpTransport = args => {
   const socket = dgram.createSocket('udp4');
+  // do not block node from shutting down
+  socket.unref();
+
   const dnsResolutionData = {
     timestamp: new Date(0),
     resolvedAddress: undefined

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "coverage": "nyc --reporter=lcov --reporter=text npm test",
-    "test": "mocha --exit -R spec --timeout 5000 test/*.js",
+    "test": "mocha -R spec --timeout 5000 test/*.js",
     "lint": "eslint lib/**/*.js test/**/*.js",
     "pretest": "npm run lint"
   },

--- a/test/close.js
+++ b/test/close.js
@@ -102,7 +102,7 @@ describe('#close', () => {
           }), clientType);
 
           // copy the real socket so it can cleaned up at the end
-          const socketRef = Object.assign({}, statsd.socket)
+          const socketRef = { ...statsd.socket };
 
           statsd.socket.destroy = () => {
             throw new Error('Boom!');

--- a/test/close.js
+++ b/test/close.js
@@ -102,7 +102,7 @@ describe('#close', () => {
           }), clientType);
 
           // copy the real socket so it can cleaned up at the end
-          const socketRef = { ...statsd.socket };
+          const socketRef = Object.assign({}, statsd.socket);
 
           statsd.socket.destroy = () => {
             throw new Error('Boom!');

--- a/test/close.js
+++ b/test/close.js
@@ -100,11 +100,20 @@ describe('#close', () => {
               done();
             }
           }), clientType);
+
+          // copy the real socket so it can cleaned up at the end
+          const socketRef = Object.assign({}, statsd.socket)
+
           statsd.socket.destroy = () => {
             throw new Error('Boom!');
           };
+
           statsd.socket.close = statsd.socket.destroy;
+
           statsd.close();
+
+          // cleanup socket
+          socketRef.close();
         });
       });
     });

--- a/test/udpDnsCacheTransport.js
+++ b/test/udpDnsCacheTransport.js
@@ -32,6 +32,7 @@ function SocketMock() {
     this.sendCount++;
     callback();
   };
+  // eslint-disable-next-line no-empty-function
   this.unref = () => {};
 }
 

--- a/test/udpDnsCacheTransport.js
+++ b/test/udpDnsCacheTransport.js
@@ -32,6 +32,7 @@ function SocketMock() {
     this.sendCount++;
     callback();
   };
+  this.unref = () => {};
 }
 
 const mockDgramSocket = () => {


### PR DESCRIPTION
Need to call `unref` on sockets and interval timers so node isn't blocked from shutting down. I noticed this problem as my tests weren't exiting. Since this fixes the problem I removed `--exit` from mocha options as we don't need to force exit anymore.

https://nodejs.org/api/timers.html#timers_timeout_unref
https://nodejs.org/api/net.html#net_socket_unref