### PR TITLE
Add asyncDistTimer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ includes all changes in the latest node-statsd and many additional changes, incl
 * raw stream protocol support
 * mock mode
 * asyncTimer
+* asyncDistTimer
 * much more, including many bug fixes
 
 hot-shots supports Node 8.x and higher.
@@ -170,10 +171,17 @@ The check method has the following API:
   var fn = function(a, b) { return a + b };
   client.timer(fn, 'fn_execution_time')(2, 2);
 
-  // Async timer: Similar to timer above, but you instead pass in a funtion
+  // Async timer: Similar to timer above, but you instead pass in a function
   // that returns a Promise.  And then it returns a Promise that will record the timing.
   var fn = function () { return new Promise(function (resolve, reject) { setTimeout(resolve, n); }); };
   var instrumented = statsd.asyncTimer(fn, 'fn_execution_time');
+  instrumented().then(function() {
+    console.log('Code run and metric sent');
+  });
+
+  // Async timer: Similar to asyncTimer above, but it instead emits a distribution.
+  var fn = function () { return new Promise(function (resolve, reject) { setTimeout(resolve, n); }); };
+  var instrumented = statsd.asyncDistTimer(fn, 'fn_execution_time');
   instrumented().then(function() {
     console.log('Code run and metric sent');
   });

--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -55,7 +55,7 @@ function applyStatsFns (Client) {
   /**
    * Decorates an async function with timing recording behaviour.
    *
-   * This version of `timer` will record the time take for the asyncronus action returned by `func`
+   * This version of `timer` will record the time take for the asynchronous action returned by `func`
    * not just the execution time of `func` itself.
    *
    * @param func {<T,A>(...A):Promise<T>} The function to run
@@ -70,6 +70,29 @@ function applyStatsFns (Client) {
       const end = hrtimer();
       const p = func(...args);
       const recordStat = () => { self.timing(stat, end(), sampleRate, tags, callback); };
+      p.then(recordStat, recordStat);
+      return p;
+    };
+  };
+
+  /**
+   * Decorates an async function with timing recording behaviour, reported as a distribution.
+   *
+   * This version of `timer` will record the time take for the asynchronous action returned by `func`
+   * not just the execution time of `func` itself.
+   *
+   * @param func {<T,A>(...A):Promise<T>} The function to run
+   * @param stat {String|Array} The stat(s) to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.asyncDistTimer = function (func, stat, sampleRate, tags, callback) {
+    const self = this;
+    return (...args) => {
+      const end = hrtimer();
+      const p = func(...args);
+      const recordStat = () => self.distribution(stat, end(), sampleRate, tags, callback);
       p.then(recordStat, recordStat);
       return p;
     };

--- a/test/timer.js
+++ b/test/timer.js
@@ -88,6 +88,26 @@ describe('#timer', () => {
       assert.ok(parseFloat(time) < (100 + TIMER_BUFFER));
     });
   });
+
+  it('should record "user time" of promise using a distribution', () => {
+    /* globals Promise */
+    statsd = new StatsD({ mock:true });
+
+    const onehundredMsFunc = () => { return delay(100); };
+
+    const instrumented = statsd.asyncDistTimer(onehundredMsFunc, 'name-thingy');
+
+    return instrumented().then(() => {
+
+      const stat = statsd.mockBuffer[0];
+      const name = stat.split(/:|\|/)[0];
+      const time = stat.split(/:|\|/)[1];
+
+      assert.equal(name, 'name-thingy');
+      assert.ok(parseFloat(time) >= 99);
+      assert.ok(parseFloat(time) < (100 + TIMER_BUFFER));
+    });
+  });
 });
 
 /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -100,6 +100,11 @@ declare module "hot-shots" {
     asyncTimer<P extends any[], R>(func: (...args: P) => Promise<R>, stat: string | string[], callback?: StatsCb): (...args: P) => Promise<R>;
     asyncTimer<P extends any[], R>(func: (...args: P) => Promise<R>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => Promise<R>;
 
+    asyncDistTimer<P extends any[], R>(func: (...args: P) => Promise<R>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
+    asyncDistTimer<P extends any[], R>(func: (...args: P) => Promise<R>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
+    asyncDistTimer<P extends any[], R>(func: (...args: P) => Promise<R>, stat: string | string[], callback?: StatsCb): (...args: P) => Promise<R>;
+    asyncDistTimer<P extends any[], R>(func: (...args: P) => Promise<R>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => Promise<R>;
+
     histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
     histogram(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
     histogram(stat: string | string[], value: number, callback?: StatsCb): void;


### PR DESCRIPTION
We're heavily moving into Datadog distributions. `asyncTimer` reports a `timing` metric (type `ms`) which is eventually a histogram in datadog. To avoid confusion (and to allow us to emit a distribution with the asyncTimer) I've created a new function called asyncDistTimer.