### PR TITLE
Fix udsGracefulErrorHandling default value

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -119,7 +119,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   // will gracefully (attempt) to re-open the socket with a small delay
   // options.udsGracefulRestartRateLimit is the minimum time (ms) between creating sockets
   // does not support options.isChild (how to re-create a socket you didn't create?)
-  if (!options.isChild && options.protocol === PROTOCOL.UDS && options.udsGracefulErrorHandling) {
+  if (!options.isChild && options.protocol === PROTOCOL.UDS && this.udsGracefulErrorHandling) {
     const socketCreateLimit = options.udsGracefulRestartRateLimit || UDS_DEFAULT_GRACEFUL_RESTART_LIMIT; // only recreate once per second
     const lastSocketCreateTime = Date.now();
     this.socket.on('error', (err) => {

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -188,7 +188,6 @@ describe('#errorHandling', () => {
           server = createServer('uds_broken', opts => {
             const client = statsd = createHotShotsClient(Object.assign(opts, {
               protocol: 'uds',
-              udsGracefulErrorHandling: true,
               errorHandler(error) {
                 assert.ok(error);
                 assert.equal(error.code, code);
@@ -222,7 +221,6 @@ describe('#errorHandling', () => {
           server = createServer('uds_broken', opts => {
             const client = statsd = createHotShotsClient(Object.assign(opts, {
               protocol: 'uds',
-              udsGracefulErrorHandling: true,
               errorHandler(error) {
                 assert.ok(error);
                 assert.equal(error.code, code);
@@ -257,7 +255,6 @@ describe('#errorHandling', () => {
           server = createServer('uds_broken', opts => {
             const client = statsd = createHotShotsClient(Object.assign(opts, {
               protocol: 'uds',
-              udsGracefulErrorHandling: true,
               udsGracefulRestartRateLimit: limit,
               errorHandler(error) {
                 assert.ok(error);

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -285,6 +285,40 @@ describe('#errorHandling', () => {
             }, 5);
           });
         });
+
+        it('should not re-create the socket on error for type uds with udsGracefulErrorHandling set to false', (done) => {
+          const code = 111;
+          const realDateNow = Date.now;
+          Date.now = () => '4857394578';
+          // emit an error, like a socket would
+          // 111 is connection refused
+          server = createServer('uds_broken', opts => {
+            const client = statsd = createHotShotsClient(Object.assign(opts, {
+              protocol: 'uds',
+              udsGracefulErrorHandling: false,
+              errorHandler(error) {
+                assert.ok(error);
+                assert.equal(error.code, code);
+              }
+            }), 'client');
+            const initialSocket = client.socket;
+            setTimeout(() => {
+              initialSocket.emit('error', { code });
+              assert.ok(Object.is(initialSocket, client.socket));
+              // it should not create the socket anyway if it breaks too quickly
+              // change time and make another error
+              Date.now = () => 4857394578 + 1000; // 1 second later
+              initialSocket.emit('error', { code });
+              setTimeout(() => {
+                // make sure the socket was NOT re-created
+                assert.equal(initialSocket, client.socket);
+                // put things back
+                Date.now = realDateNow;
+                done();
+              }, 5);
+            }, 5);
+          });
+        });
       }
     });
   });


### PR DESCRIPTION
Fixes https://github.com/brightcove/hot-shots/issues/172 where `udsGracefulErrorHandling` is only used when explicitly set in the options.