### PR TITLE
Add option to snake case tags before sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Parameters (specified as one object passed into hot-shots):
   the server and allowing data to be read from mockBuffer.  Note that
   mockBuffer will keep growing, so only use for testing or clear out periodically. `default: false`
 * `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. The *Datadog* `dd.internal.entity_id` tag is appended to `globalTags` from the `DD_ENTITY_ID` environment variable if the latter is set. `default: {}`
+* `snakeCaseTags`: If true, converts all tags to snake case using [snake-case](https://github.com/blakeembrey/change-case/tree/master/packages/snake-case). This can be useful as Datadog ignores case in its metrics.
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0`
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { snakeCase } = require('snake-case');
 
 /**
  * Replace any characters that can't be sent on with an underscore
@@ -58,6 +59,21 @@ function overrideTags (parent, child, telegraf) {
 }
 
 /**
+ * Overrides tags with snake-cased versions. This allows codebases where camelcase is necessary
+ * to use snake case when sending stats.
+ */
+function snakeCaseTags(tags) {
+  return tags.map(tag => {
+    const idx = typeof tag === 'string' ? tag.indexOf(':') : -1;
+    if (idx < 1) { // Not found or first character
+      return snakeCase(tag);
+    } else {
+      return snakeCase(tag.substring(0, idx)) + ':' + snakeCase(tag.substring(idx + 1));
+    }
+  });
+}
+
+/**
  * Formats a date for use with DataDog
  */
 function formatDate(date) {
@@ -109,6 +125,7 @@ function getDefaultRoute() {
 module.exports = {
   formatTags: formatTags,
   overrideTags: overrideTags,
+  snakeCaseTags: snakeCaseTags,
   formatDate: formatDate,
   getDefaultRoute: getDefaultRoute,
   sanitizeTags: sanitizeTags

--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -1,4 +1,5 @@
 const helpers = require('./helpers');
+const { snakeCase } = require('snake-case');
 
 /**
  * Separated out of statsd.js for clarity, these are the timing and other stats functions that are what are called the most
@@ -251,6 +252,9 @@ function applyStatsFns (Client) {
     let mergedTags = this.globalTags;
     if (tags && typeof(tags) === 'object') {
       mergedTags = helpers.overrideTags(mergedTags, tags, this.telegraf);
+    }
+    if (this.snakeCaseTags) {
+      mergedTags = snakeCase(mergedTags);
     }
     if (mergedTags.length > 0) {
       check.push(`#${mergedTags.join(',')}`);

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -61,6 +61,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
    });
     this.globalTags.push('dd.internal.entity_id:'.concat(helpers.sanitizeTags(process.env.DD_ENTITY_ID)));
   }
+  this.snakeCaseTags = options.snakeCaseTags || false;
   this.telegraf = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;
   this.sampleRate = options.sampleRate || 1;
@@ -266,6 +267,9 @@ Client.prototype.send = function (message, tags, callback) {
   let mergedTags = this.globalTags;
   if (tags && typeof tags === 'object') {
     mergedTags = helpers.overrideTags(mergedTags, tags, this.telegraf);
+  }
+  if (this.snakeCaseTags) {
+    mergedTags = helpers.snakeCaseTags(mergedTags);
   }
   if (mergedTags.length > 0) {
     if (this.telegraf) {
@@ -503,6 +507,8 @@ const ChildClient = function (parent, options) {
     // Append child's tags to parent's tags
     globalTags  : typeof options.globalTags === 'object' ?
         helpers.overrideTags(parent.globalTags, options.globalTags, parent.telegraf) : parent.globalTags,
+    // use parent's snakeCaseTags property if options does not specify
+    snakeCaseTags: typeof options.snakeCaseTags === 'undefined' ? parent.snakeCaseTags : options.snakeCaseTags,
     maxBufferSize : parent.maxBufferSize,
     bufferFlushInterval: parent.bufferFlushInterval,
     telegraf    : parent.telegraf,

--- a/package-lock.json
+++ b/package-lock.json
@@ -622,6 +622,15 @@
         "esutils": "^2.0.2"
       }
     },
+    "dot-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1460,6 +1469,14 @@
         "chalk": "^2.0.1"
       }
     },
+    "lower-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -1607,6 +1624,15 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -2204,6 +2230,15 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "snake-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz",
+      "integrity": "sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==",
+      "requires": {
+        "dot-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2413,8 +2448,7 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,7 @@
     "nyc": "15.x"
   },
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "snake-case": "^3.0.3"
+  }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,6 +9,7 @@ declare module "hot-shots" {
     cacheDnsTtl?: number;
     errorHandler?: (err: Error) => void;
     globalTags?: Tags;
+    snakeCaseTags?: boolean;
     globalize?: boolean;
     host?: string;
     isChild?: boolean;


### PR DESCRIPTION
One thing I found while using this package is that my codebase enforces camelCase naming of object properties, but datadog lowercases everything so snake_case is generally ideal. This adds an option to automatically snake case tags before sending out.