### PR TITLE
replace 'localhost' fallback with undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ You can check the detailed [change log](https://github.com/brightcove/hot-shots/
 All initialization parameters are optional.
 
 Parameters (specified as one object passed into hot-shots):
-* `host`:        The host to send stats to, if not set, the constructor tries to retrieve it from the `DD_AGENT_HOST` environment variable, `default: localhost`
+
+* `host`:        The host to send stats to, if not set, the constructor tries to
+  retrieve it from the `DD_AGENT_HOST` environment variable, `default: 'undefined'` which as per [UDP/datagram socket docs](https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback) results in `127.0.0.1` or `::1` being used.
 * `port`:        The port to send stats to, if not set, the constructor tries to retrieve it from the `DD_DOGSTATSD_PORT` environment variable, `default: 8125`
 * `prefix`:      What to prefix each stat name with `default: ''`
 * `suffix`:      What to suffix each stat name with `default: ''`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -46,7 +46,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   }
   this.cacheDns = options.cacheDns === true;
   this.cacheDnsTtl = options.cacheDnsTtl || CACHE_DNS_TTL_DEFAULT;
-  this.host = options.host || process.env.DD_AGENT_HOST || 'localhost';
+  this.host = options.host || process.env.DD_AGENT_HOST;
   this.port = options.port || parseInt(process.env.DD_DOGSTATSD_PORT, 10) || 8125;
   this.prefix = options.prefix || '';
   this.suffix = options.suffix || '';

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -27,7 +27,7 @@ describe('#buffer', () => {
           statsd.increment('b', 2);
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, 'a:1|c\nb:2|c\n');
+          assert.strictEqual(metrics, 'a:1|c\nb:2|c\n');
           done();
         });
       });
@@ -47,16 +47,16 @@ describe('#buffer', () => {
           // one of the few places we have an actual test difference based on server type
           if (serverType === 'udp' || serverType === 'uds' || serverType === 'stream') {
             const index = expected.indexOf(metrics.trim());
-            assert.equal(index >= 0, true);
+            assert.strictEqual(index >= 0, true);
             expected.splice(index, 1);
             noOfMessages++;
             if (noOfMessages === 2) {
-              assert.equal(expected.length, 0);
+              assert.strictEqual(expected.length, 0);
               done();
             }
           }
           else {
-            assert.equal(metrics, 'a:1|c\nb:2|c\n');
+            assert.strictEqual(metrics, 'a:1|c\nb:2|c\n');
             done();
           }
         });
@@ -71,7 +71,7 @@ describe('#buffer', () => {
           statsd.increment('b', 2);
         });
         server.once('metrics', metrics => {
-          assert.equal(metrics, 'a:1|c\n');
+          assert.strictEqual(metrics, 'a:1|c\n');
           done();
         });
       });
@@ -88,8 +88,8 @@ describe('#buffer', () => {
         });
         server.on('metrics', metric => {
           const elapsed = Date.now() - start;
-          assert.equal(metric, 'a:1|c\n');
-          assert.equal(elapsed > 1000, true);
+          assert.strictEqual(metric, 'a:1|c\n');
+          assert.strictEqual(elapsed > 1000, true);
           done();
         });
       });

--- a/test/check.js
+++ b/test/check.js
@@ -24,7 +24,7 @@ describe('#check', () => {
           statsd.check('check.name', statsd.CHECKS.OK);
         });
         server.on('metrics', event => {
-          assert.equal(event, `_sc|check.name|0${metricEnd}`);
+          assert.strictEqual(event, `_sc|check.name|0${metricEnd}`);
           done();
         });
       });
@@ -38,7 +38,7 @@ describe('#check', () => {
           statsd.check('check.name', statsd.CHECKS.OK);
         });
         server.on('metrics', event => {
-          assert.equal(event, `_sc|prefix.check.name.suffix|0${metricEnd}`);
+          assert.strictEqual(event, `_sc|prefix.check.name.suffix|0${metricEnd}`);
           done();
         });
       });
@@ -55,7 +55,7 @@ describe('#check', () => {
           statsd.check('check.name', statsd.CHECKS.WARNING, options);
         });
         server.on('metrics', event => {
-          assert.equal(event, `_sc|check.name|1|d:${Math.round(date.getTime() / 1000)}|h:host|m:message${metricEnd}`
+          assert.strictEqual(event, `_sc|check.name|1|d:${Math.round(date.getTime() / 1000)}|h:host|m:message${metricEnd}`
           );
           done();
         });
@@ -70,7 +70,7 @@ describe('#check', () => {
           statsd.event('test title', 'another desc', options, ['foo', 'bar']);
         });
         server.on('metrics', event => {
-          assert.equal(event, `_e{10,12}:test title|another desc|h:host|#foo,bar${metricEnd}`);
+          assert.strictEqual(event, `_e{10,12}:test title|another desc|h:host|#foo,bar${metricEnd}`);
           done();
         });
       });
@@ -84,8 +84,8 @@ describe('#check', () => {
           });
         });
         server.on('metrics', event => {
-          assert.equal(event, `_sc|check.name|0|#foo,bar${metricEnd}`);
-          assert.equal(called, true);
+          assert.strictEqual(event, `_sc|check.name|0|#foo,bar${metricEnd}`);
+          assert.strictEqual(called, true);
           done();
         });
       });

--- a/test/childClient.js
+++ b/test/childClient.js
@@ -35,9 +35,9 @@ describe('#childClient', () => {
           globalTags: ['awesomeness:over9000', 'tag1:xxx', 'bar', ':baz']
         });
 
-        assert.equal(child.prefix, 'preff.prefix');
-        assert.equal(child.suffix, 'suffix.suff');
-        assert.equal(statsd, global.statsd);
+        assert.strictEqual(child.prefix, 'preff.prefix');
+        assert.strictEqual(child.suffix, 'suffix.suff');
+        assert.strictEqual(statsd, global.statsd);
         assert.deepEqual(child.globalTags, ['gtag', 'tag1:xxx', 'awesomeness:over9000', 'bar', ':baz']);
       });
     });
@@ -55,7 +55,7 @@ describe('#childClient', () => {
           statsd.increment('b', 2);
       });
       server.on('metrics', metrics => {
-        assert.equal(metrics, 'preff.a.suff:1|c|#awesomeness:over9000\npreff.b.suff:2|c|#awesomeness:over9000\n');
+        assert.strictEqual(metrics, 'preff.a.suff:1|c|#awesomeness:over9000\npreff.b.suff:2|c|#awesomeness:over9000\n');
         done();
       });
     });
@@ -76,7 +76,7 @@ describe('#childClient', () => {
         statsd.increment('b', 2);
       });
       server.on('metrics', metrics => {
-        assert.equal(metrics, 'preff.p.a.s.suff:1|c|#xyz,awesomeness:' +
+        assert.strictEqual(metrics, 'preff.p.a.s.suff:1|c|#xyz,awesomeness:' +
           'over9000\npreff.p.b.s.suff:2|c|#xyz,awesomeness:over9000\n'
         );
         done();

--- a/test/close.js
+++ b/test/close.js
@@ -37,7 +37,7 @@ describe('#close', () => {
           });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:42|s${metricsEnd}`);
+          assert.strictEqual(metrics, `test:42|s${metricsEnd}`);
           metricSeen = true;
         });
       });
@@ -62,7 +62,7 @@ describe('#close', () => {
         server.on('metrics', metrics => {
           // this uses '\n' instead of metricsEnd because that's how things are set up when
           // maxBufferSize is in use
-          assert.equal(metrics, 'test:42|s\n');
+          assert.strictEqual(metrics, 'test:42|s\n');
           metricSeen = true;
         });
       });
@@ -87,7 +87,7 @@ describe('#close', () => {
         server.on('metrics', metrics => {
           // this uses '\n' instead of metricsEnd because that's how things are set up when
           // maxBufferSize is in use
-          assert.equal(metrics, 'test:42|s\n');
+          assert.strictEqual(metrics, 'test:42|s\n');
           metricSeen = true;
         });
       });

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -85,7 +85,7 @@ describe('#errorHandling', () => {
           const err = new Error('Boom!');
           statsd = createHotShotsClient(Object.assign(opts, {
             errorHandler(e) {
-              assert.equal(e, err);
+              assert.strictEqual(e, err);
               done();
             }
           }), clientType);
@@ -101,7 +101,7 @@ describe('#errorHandling', () => {
           const err = new Error('Boom!');
           statsd = createHotShotsClient(Object.assign(opts, {
             errorHandler(e) {
-              assert.equal(e, err);
+              assert.strictEqual(e, err);
               ignoreErrors = true;
               done();
             }
@@ -125,7 +125,7 @@ describe('#errorHandling', () => {
 
         statsd.send('test title', [], error => {
           assert.ok(error);
-          assert.equal(error.code, 'ENOTFOUND');
+          assert.strictEqual(error.code, 'ENOTFOUND');
           // skip closing, because the unresolvable host hangs
           statsd = null;
           done();
@@ -145,7 +145,7 @@ describe('#errorHandling', () => {
           protocol: serverType,
           errorHandler(error) {
             assert.ok(error);
-            assert.equal(error.code, 'ENOTFOUND');
+            assert.strictEqual(error.code, 'ENOTFOUND');
             // skip closing, because the unresolvable host hangs
             statsd = null;
             done();
@@ -168,7 +168,7 @@ describe('#errorHandling', () => {
 
         statsd.socket.on('error', error => {
           assert.ok(error);
-          assert.equal(error.code, 'ENOTFOUND');
+          assert.strictEqual(error.code, 'ENOTFOUND');
 
           // skip closing, because the unresolvable host hangs
           statsd = null;
@@ -190,7 +190,7 @@ describe('#errorHandling', () => {
               protocol: 'uds',
               errorHandler(error) {
                 assert.ok(error);
-                assert.equal(error.code, code);
+                assert.strictEqual(error.code, code);
               }
             }), 'client');
             const initialSocket = client.socket;
@@ -223,7 +223,7 @@ describe('#errorHandling', () => {
               protocol: 'uds',
               errorHandler(error) {
                 assert.ok(error);
-                assert.equal(error.code, code);
+                assert.strictEqual(error.code, code);
               }
             }), 'client');
             const initialSocket = client.socket;
@@ -258,7 +258,7 @@ describe('#errorHandling', () => {
               udsGracefulRestartRateLimit: limit,
               errorHandler(error) {
                 assert.ok(error);
-                assert.equal(error.code, code);
+                assert.strictEqual(error.code, code);
               }
             }), 'client');
             const initialSocket = client.socket;
@@ -271,7 +271,7 @@ describe('#errorHandling', () => {
               initialSocket.emit('error', { code });
               setTimeout(() => {
                 // make sure the socket was NOT re-created
-                assert.equal(initialSocket, client.socket);
+                assert.strictEqual(initialSocket, client.socket);
                 Date.now = () => 4857394578 + limit; // 1 second later
                 initialSocket.emit('error', { code });
                 setTimeout(() => {
@@ -298,7 +298,7 @@ describe('#errorHandling', () => {
               udsGracefulErrorHandling: false,
               errorHandler(error) {
                 assert.ok(error);
-                assert.equal(error.code, code);
+                assert.strictEqual(error.code, code);
               }
             }), 'client');
             const initialSocket = client.socket;
@@ -311,7 +311,7 @@ describe('#errorHandling', () => {
               initialSocket.emit('error', { code });
               setTimeout(() => {
                 // make sure the socket was NOT re-created
-                assert.equal(initialSocket, client.socket);
+                assert.strictEqual(initialSocket, client.socket);
                 // put things back
                 Date.now = realDateNow;
                 done();

--- a/test/event.js
+++ b/test/event.js
@@ -22,7 +22,7 @@ describe('#event', () => {
           statsd.event('test', 'description');
         });
         server.on('metrics', event => {
-          assert.equal(event, `_e{4,11}:test|description${metricEnd}`);
+          assert.strictEqual(event, `_e{4,11}:test|description${metricEnd}`);
           done();
         });
       });
@@ -33,7 +33,7 @@ describe('#event', () => {
           statsd.event('test');
         });
         server.on('metrics', event => {
-          assert.equal(event, `_e{4,4}:test|test${metricEnd}`);
+          assert.strictEqual(event, `_e{4,4}:test|test${metricEnd}`);
           done();
         });
       });
@@ -53,7 +53,7 @@ describe('#event', () => {
           statsd.event('test title', 'another\nmultiline\ndescription', options);
         });
         server.on('metrics', event => {
-          assert.equal(event, `_e{10,31}:test title|another\\nmultiline\\ndescription|d:${Math.round(date.getTime() / 1000)}|h:host|k:ag_key|p:low|s:source_type|t:warning${metricEnd}`
+          assert.strictEqual(event, `_e{10,31}:test title|another\\nmultiline\\ndescription|d:${Math.round(date.getTime() / 1000)}|h:host|k:ag_key|p:low|s:source_type|t:warning${metricEnd}`
           );
           done();
         });
@@ -68,7 +68,7 @@ describe('#event', () => {
           statsd.event('test title', 'another desc', options, ['foo', 'bar']);
         });
         server.on('metrics', event => {
-          assert.equal(event, `_e{10,12}:test title|another desc|h:host|#foo,bar${metricEnd}`);
+          assert.strictEqual(event, `_e{10,12}:test title|another desc|h:host|#foo,bar${metricEnd}`);
           done();
         });
       });
@@ -82,8 +82,8 @@ describe('#event', () => {
           });
         });
         server.on('metrics', event => {
-          assert.equal(event, `_e{10,12}:test title|another desc|#foo,bar${metricEnd}`);
-          assert.equal(called, true);
+          assert.strictEqual(event, `_e{10,12}:test title|another desc|#foo,bar${metricEnd}`);
+          assert.strictEqual(called, true);
           done();
         });
       });

--- a/test/globalTags.js
+++ b/test/globalTags.js
@@ -23,7 +23,7 @@ describe('#globalTags', () => {
           statsd.increment('test');
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1|c${metricEnd}`);
+          assert.strictEqual(metrics, `test:1|c${metricEnd}`);
           done();
         });
       });
@@ -36,7 +36,7 @@ describe('#globalTags', () => {
           statsd.increment('test');
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1|c|#gtag${metricEnd}`);
+          assert.strictEqual(metrics, `test:1|c|#gtag${metricEnd}`);
           done();
         });
       });
@@ -52,7 +52,7 @@ describe('#globalTags', () => {
           statsd.increment('test');
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1|c|#gtag,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d${metricEnd}`);
+          assert.strictEqual(metrics, `test:1|c|#gtag,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d${metricEnd}`);
           done();
         });
       });
@@ -65,7 +65,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, ['foo']);
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#gtag,foo${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|#gtag,foo${metricEnd}`);
           done();
         });
       });
@@ -78,7 +78,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, ['gtag:234', 'bar']);
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#foo,gtag:234,bar${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|#foo,gtag:234,bar${metricEnd}`);
           done();
         });
       });
@@ -91,7 +91,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#gtag:234,foo:bar${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|#gtag:234,foo:bar${metricEnd}`);
           done();
         });
       });
@@ -105,7 +105,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|~gtag:234,foo:bar${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|~gtag:234,foo:bar${metricEnd}`);
           done();
         });
       });
@@ -119,7 +119,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#gtag:234~foo:bar${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|#gtag:234~foo:bar${metricEnd}`);
           done();
         });
       });
@@ -134,7 +134,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|~gtag:234~foo:bar${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|~gtag:234~foo:bar${metricEnd}`);
           done();
         });
       });
@@ -147,7 +147,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { 'reserved:character': 'is@replaced@' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#foo:b_a_r,reserved_character:is_replaced_${metricEnd}`);
+          assert.strictEqual(metrics, `test:1337|c|#foo:b_a_r,reserved_character:is_replaced_${metricEnd}`);
           done();
         });
       });
@@ -161,7 +161,7 @@ describe('#globalTags', () => {
           statsd.increment('test');
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test,gtag=gvalue,gtag2=gvalue2:1|c${metricEnd}`);
+          assert.strictEqual(metrics, `test,gtag=gvalue,gtag2=gvalue2:1|c${metricEnd}`);
           done();
         });
       });
@@ -175,7 +175,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, ['foo:bar']);
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test,gtag=gvalue,foo=bar:1337|c${metricEnd}`);
+          assert.strictEqual(metrics, `test,gtag=gvalue,foo=bar:1337|c${metricEnd}`);
           done();
         });
       });
@@ -189,7 +189,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { foo: 'bar' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test,gtag=gvalue,foo=bar:1337|c${metricEnd}`);
+          assert.strictEqual(metrics, `test,gtag=gvalue,foo=bar:1337|c${metricEnd}`);
           done();
         });
       });

--- a/test/init.js
+++ b/test/init.js
@@ -37,18 +37,18 @@ describe('#init', () => {
       clientType
     );
 
-    assert.equal(statsd.host, 'host');
-    assert.equal(statsd.port, 1234);
-    assert.equal(statsd.prefix, 'prefix');
-    assert.equal(statsd.suffix, 'suffix');
-    assert.equal(statsd, global.statsd);
-    assert.equal(statsd.mock, true);
-    assert.deepEqual(statsd.globalTags, ['gtag']);
-    assert.equal(statsd.maxBufferSize, 0);
-    assert.equal(statsd.bufferFlushInterval, 60);
-    assert.equal(statsd.telegraf, false);
-    assert.equal(statsd.sampleRate, 0.5);
-    assert.equal(statsd.protocol, 'udp');
+    assert.strictEqual(statsd.host, 'host');
+    assert.strictEqual(statsd.port, 1234);
+    assert.strictEqual(statsd.prefix, 'prefix');
+    assert.strictEqual(statsd.suffix, 'suffix');
+    assert.strictEqual(statsd, global.statsd);
+    assert.strictEqual(statsd.mock, true);
+    assert.deepStrictEqual(statsd.globalTags, ['gtag']);
+    assert.strictEqual(statsd.maxBufferSize, 0);
+    assert.strictEqual(statsd.bufferFlushInterval, 60);
+    assert.strictEqual(statsd.telegraf, false);
+    assert.strictEqual(statsd.sampleRate, 0.5);
+    assert.strictEqual(statsd.protocol, 'udp');
   });
 
   it('should set the proper values with options hash format', () => {
@@ -72,18 +72,18 @@ describe('#init', () => {
       protocol: 'tcp'
     }, clientType);
 
-    assert.equal(statsd.host, 'host');
-    assert.equal(statsd.port, 1234);
-    assert.equal(statsd.prefix, 'prefix');
-    assert.equal(statsd.suffix, 'suffix');
-    assert.equal(statsd, global.statsd);
-    assert.equal(statsd.mock, true);
-    assert.equal(statsd.sampleRate, 0.6);
-    assert.deepEqual(statsd.globalTags, ['gtag']);
-    assert.equal(statsd.maxBufferSize, 0);
-    assert.equal(statsd.bufferFlushInterval, 60);
-    assert.deepEqual(statsd.telegraf, false);
-    assert.equal(statsd.protocol, 'tcp');
+    assert.strictEqual(statsd.host, 'host');
+    assert.strictEqual(statsd.port, 1234);
+    assert.strictEqual(statsd.prefix, 'prefix');
+    assert.strictEqual(statsd.suffix, 'suffix');
+    assert.strictEqual(statsd, global.statsd);
+    assert.strictEqual(statsd.mock, true);
+    assert.strictEqual(statsd.sampleRate, 0.6);
+    assert.deepStrictEqual(statsd.globalTags, ['gtag']);
+    assert.strictEqual(statsd.maxBufferSize, 0);
+    assert.strictEqual(statsd.bufferFlushInterval, 60);
+    assert.deepStrictEqual(statsd.telegraf, false);
+    assert.strictEqual(statsd.protocol, 'tcp');
 
     dns.lookup = originalLookup;
   });
@@ -94,41 +94,41 @@ describe('#init', () => {
     process.env.DD_DOGSTATSD_PORT = '1234';
 
     statsd = createHotShotsClient({}, clientType);
-    assert.equal(statsd.host, 'envhost');
-    assert.equal(statsd.port, 1234);
-    assert.equal(statsd.prefix, '');
-    assert.equal(statsd.suffix, '');
-    assert.equal(global.statsd, undefined);
-    assert.equal(statsd.mock, undefined);
-    assert.deepEqual(statsd.globalTags, []);
+    assert.strictEqual(statsd.host, 'envhost');
+    assert.strictEqual(statsd.port, 1234);
+    assert.strictEqual(statsd.prefix, '');
+    assert.strictEqual(statsd.suffix, '');
+    assert.strictEqual(global.statsd, undefined);
+    assert.strictEqual(statsd.mock, undefined);
+    assert.deepStrictEqual(statsd.globalTags, []);
     assert.ok(!statsd.mock);
-    assert.equal(statsd.sampleRate, 1);
-    assert.equal(statsd.maxBufferSize, 0);
-    assert.equal(statsd.bufferFlushInterval, 1000);
-    assert.equal(statsd.telegraf, false);
-    assert.equal(statsd.protocol, 'udp');
+    assert.strictEqual(statsd.sampleRate, 1);
+    assert.strictEqual(statsd.maxBufferSize, 0);
+    assert.strictEqual(statsd.bufferFlushInterval, 1000);
+    assert.strictEqual(statsd.telegraf, false);
+    assert.strictEqual(statsd.protocol, 'udp');
   });
 
   it('should set default values when not specified', () => {
     statsd = createHotShotsClient({}, clientType);
-    assert.equal(statsd.host, undefined);
-    assert.equal(statsd.port, 8125);
-    assert.equal(statsd.prefix, '');
-    assert.equal(statsd.suffix, '');
-    assert.equal(global.statsd, undefined);
-    assert.equal(statsd.mock, undefined);
-    assert.deepEqual(statsd.globalTags, []);
+    assert.strictEqual(statsd.host, undefined);
+    assert.strictEqual(statsd.port, 8125);
+    assert.strictEqual(statsd.prefix, '');
+    assert.strictEqual(statsd.suffix, '');
+    assert.strictEqual(global.statsd, undefined);
+    assert.strictEqual(statsd.mock, undefined);
+    assert.deepStrictEqual(statsd.globalTags, []);
     assert.ok(!statsd.mock);
-    assert.equal(statsd.sampleRate, 1);
-    assert.equal(statsd.maxBufferSize, 0);
-    assert.equal(statsd.bufferFlushInterval, 1000);
-    assert.equal(statsd.telegraf, false);
-    assert.equal(statsd.protocol, 'udp');
+    assert.strictEqual(statsd.sampleRate, 1);
+    assert.strictEqual(statsd.maxBufferSize, 0);
+    assert.strictEqual(statsd.bufferFlushInterval, 1000);
+    assert.strictEqual(statsd.telegraf, false);
+    assert.strictEqual(statsd.protocol, 'udp');
   });
 
   it('should map global_tags to globalTags for backwards compatibility', () => {
     statsd = createHotShotsClient({ global_tags: ['gtag'] }, clientType);
-    assert.deepEqual(statsd.globalTags, ['gtag']);
+    assert.deepStrictEqual(statsd.globalTags, ['gtag']);
   });
 
   it('should get the dd.internal.entity_id tag from DD_ENTITY_ID env var', () => {
@@ -136,7 +136,7 @@ describe('#init', () => {
     process.env.DD_ENTITY_ID = '04652bb7-19b7-11e9-9cc6-42010a9c016d';
 
     statsd = createHotShotsClient({}, clientType);
-    assert.deepEqual(statsd.globalTags, ['dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
+    assert.deepStrictEqual(statsd.globalTags, ['dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
   });
 
   it('should get the dd.internal.entity_id tag from DD_ENTITY_ID env var and append it to existing tags', () => {
@@ -144,7 +144,7 @@ describe('#init', () => {
     process.env.DD_ENTITY_ID = '04652bb7-19b7-11e9-9cc6-42010a9c016d';
 
     statsd = createHotShotsClient({ globalTags: ['gtag'] }, clientType);
-    assert.deepEqual(statsd.globalTags, ['gtag', 'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
+    assert.deepStrictEqual(statsd.globalTags, ['gtag', 'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
   });
 
   it('should not lookup a dns record if dnsCache is not specified', done => {
@@ -174,7 +174,7 @@ describe('#init', () => {
     statsd = createHotShotsClient({ host: 'test', cacheDns: true }, clientType);
 
     statsd.increment('test', 1, 1, null, err => {
-      assert.equal(err.message, 'Error sending hot-shots message: Error: Bad host');
+      assert.strictEqual(err.message, 'Error sending hot-shots message: Error: Bad host');
       dns.lookup = originalLookup;
       done();
     });
@@ -187,7 +187,7 @@ describe('#init', () => {
 
   it('should not create a global variable when not specified', () => {
     statsd = createHotShotsClient(['host', 1234, 'prefix', 'suffix'], clientType);
-    assert.equal(global.statsd, undefined);
+    assert.strictEqual(global.statsd, undefined);
   });
 
   it('should create a mock Client when mock variable is specified', () => {
@@ -197,14 +197,14 @@ describe('#init', () => {
 
   it('should create a socket variable that is an instance of dgram.Socket', () => {
     statsd = createHotShotsClient({}, clientType);
-    assert.equal(statsd.socket.type, 'udp');
+    assert.strictEqual(statsd.socket.type, 'udp');
     skipClose = true;
   });
 
   it('should create a socket variable that is an instance of net.Socket if set to TCP', done => {
     server = createServer('tcp', opts => {
       statsd = createHotShotsClient(opts, clientType);
-      assert.equal(statsd.socket.type, 'tcp');
+      assert.strictEqual(statsd.socket.type, 'tcp');
       done();
     });
   });

--- a/test/init.js
+++ b/test/init.js
@@ -111,7 +111,7 @@ describe('#init', () => {
 
   it('should set default values when not specified', () => {
     statsd = createHotShotsClient({}, clientType);
-    assert.equal(statsd.host, 'localhost');
+    assert.equal(statsd.host, undefined);
     assert.equal(statsd.port, 8125);
     assert.equal(statsd.prefix, '');
     assert.equal(statsd.suffix, '');
@@ -156,7 +156,7 @@ describe('#init', () => {
       dns.lookup = originalLookup;
     };
 
-    statsd = createHotShotsClient({ host: 'localhost' }, clientType);
+    statsd = createHotShotsClient({ host: 'test' }, clientType);
     process.nextTick(() => {
       dns.lookup = originalLookup;
       done();
@@ -171,7 +171,7 @@ describe('#init', () => {
       return callback(new Error('Bad host'));
     };
 
-    statsd = createHotShotsClient({ host: 'localhost', cacheDns: true }, clientType);
+    statsd = createHotShotsClient({ host: 'test', cacheDns: true }, clientType);
 
     statsd.increment('test', 1, 1, null, err => {
       assert.equal(err.message, 'Error sending hot-shots message: Error: Bad host');

--- a/test/send.js
+++ b/test/send.js
@@ -21,7 +21,7 @@ describe('#send', () => {
           const err = new Error('Boom!');
           statsd = createHotShotsClient(Object.assign(opts, {
             errorHandler(e) {
-              assert.equal(e, err);
+              assert.strictEqual(e, err);
               done();
             }
           }), clientType);

--- a/test/statsFunctions.js
+++ b/test/statsFunctions.js
@@ -30,7 +30,7 @@ describe('#statsFunctions', () => {
               statsd[statFunction.name]('test', 42);
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `test:42|${statFunction.unit}${metricsEnd}`);
+              assert.strictEqual(metrics, `test:42|${statFunction.unit}${metricsEnd}`);
               done();
             });
           });
@@ -41,7 +41,7 @@ describe('#statsFunctions', () => {
               statsd[statFunction.name]('test', 42, ['foo', 'bar']);
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `test:42|${statFunction.unit}|#foo,bar${metricsEnd}`);
+              assert.strictEqual(metrics, `test:42|${statFunction.unit}|#foo,bar${metricsEnd}`);
               done();
             });
           });
@@ -54,7 +54,7 @@ describe('#statsFunctions', () => {
               statsd[statFunction.name]('test', 42, ['foo', 'bar']);
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `test:42|${statFunction.unit}|#foo,bar${metricsEnd}`);
+              assert.strictEqual(metrics, `test:42|${statFunction.unit}|#foo,bar${metricsEnd}`);
               done();
             });
           });
@@ -71,8 +71,8 @@ describe('#statsFunctions', () => {
               });
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `foo.test.bar:42|${statFunction.unit}|@0.5${metricsEnd}`);
-              assert.equal(called, true);
+              assert.strictEqual(metrics, `foo.test.bar:42|${statFunction.unit}|@0.5${metricsEnd}`);
+              assert.strictEqual(called, true);
               done();
             });
           });
@@ -87,11 +87,11 @@ describe('#statsFunctions', () => {
               statsd[statFunction.name](['a', 'b'], 42, null, (error) => {
                 called += 1;
                 assert.ok(called === 1); // Ensure it only gets called once
-                assert.equal(error, null);
+                assert.strictEqual(error, null);
               });
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `a:42|${statFunction.unit}\nb:42|${statFunction.unit}\n`);
+              assert.strictEqual(metrics, `a:42|${statFunction.unit}\nb:42|${statFunction.unit}\n`);
               done();
             });
           });
@@ -102,7 +102,7 @@ describe('#statsFunctions', () => {
               statsd[statFunction.name]('test', 42, { foo: 'bar' });
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `test:42|${statFunction.unit}|#foo:bar${metricsEnd}`);
+              assert.strictEqual(metrics, `test:42|${statFunction.unit}|#foo:bar${metricsEnd}`);
               done();
             });
           });
@@ -115,7 +115,7 @@ describe('#statsFunctions', () => {
               statsd[statFunction.name]('test', 42, { foo: 'bar' });
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `test,foo=bar:42|${statFunction.unit}${metricsEnd}`);
+              assert.strictEqual(metrics, `test,foo=bar:42|${statFunction.unit}${metricsEnd}`);
               done();
             });
           });
@@ -129,7 +129,7 @@ describe('#statsFunctions', () => {
             statsd.timing('test', 1592198027348);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:1592198027348|ms${metricsEnd}`);
+            assert.strictEqual(metrics, `test:1592198027348|ms${metricsEnd}`);
             done();
           });
         });
@@ -153,7 +153,7 @@ describe('#statsFunctions', () => {
             statsd.increment('test');
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:1|c${metricsEnd}`);
+            assert.strictEqual(metrics, `test:1|c${metricsEnd}`);
             done();
           });
         });
@@ -164,7 +164,7 @@ describe('#statsFunctions', () => {
             statsd.increment('test', 0);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:0|c${metricsEnd}`);
+            assert.strictEqual(metrics, `test:0|c${metricsEnd}`);
             done();
           });
         });
@@ -175,7 +175,7 @@ describe('#statsFunctions', () => {
             statsd.increment('test', 42, ['foo', 'bar']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:42|c|#foo,bar${metricsEnd}`);
+            assert.strictEqual(metrics, `test:42|c|#foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -186,7 +186,7 @@ describe('#statsFunctions', () => {
             statsd.increment('test', ['foo', 'bar']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:1|c|#foo,bar${metricsEnd}`);
+            assert.strictEqual(metrics, `test:1|c|#foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -197,7 +197,7 @@ describe('#statsFunctions', () => {
             statsd.increment('test', 23, ['foo', 'bar']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:23|c|#foo,bar${metricsEnd}`);
+            assert.strictEqual(metrics, `test:23|c|#foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -214,8 +214,8 @@ describe('#statsFunctions', () => {
             });
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `foo.test.bar:42|c|@0.5${metricsEnd}`);
-            assert.equal(called, true);
+            assert.strictEqual(metrics, `foo.test.bar:42|c|@0.5${metricsEnd}`);
+            assert.strictEqual(called, true);
             done();
           });
         });
@@ -230,12 +230,12 @@ describe('#statsFunctions', () => {
             statsd.increment(['a', 'b'], 42, null, (error, bytes) => {
               called += 1;
               assert.ok(called === 1); // Ensure it only gets called once
-              assert.equal(error, null);
-              assert.equal(bytes, 0);
+              assert.strictEqual(error, null);
+              assert.strictEqual(bytes, 0);
             });
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, 'a:42|c\nb:42|c\n');
+            assert.strictEqual(metrics, 'a:42|c\nb:42|c\n');
             done();
           });
         });
@@ -248,7 +248,7 @@ describe('#statsFunctions', () => {
             statsd.decrement('test');
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-1|c${metricsEnd}`);
+            assert.strictEqual(metrics, `test:-1|c${metricsEnd}`);
             done();
           });
         });
@@ -259,7 +259,7 @@ describe('#statsFunctions', () => {
             statsd.decrement('test', ['foo', 'bar']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-1|c|#foo,bar${metricsEnd}`);
+            assert.strictEqual(metrics, `test:-1|c|#foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -270,7 +270,7 @@ describe('#statsFunctions', () => {
             statsd.decrement('test', 23, ['foo', 'bar']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-23|c|#foo,bar${metricsEnd}`);
+            assert.strictEqual(metrics, `test:-23|c|#foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -281,7 +281,7 @@ describe('#statsFunctions', () => {
             statsd.decrement('test', 42, ['foo', 'bar']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-42|c|#foo,bar${metricsEnd}`);
+            assert.strictEqual(metrics, `test:-42|c|#foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -298,8 +298,8 @@ describe('#statsFunctions', () => {
             });
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `foo.test.bar:-42|c|@0.5${metricsEnd}`);
-            assert.equal(called, true);
+            assert.strictEqual(metrics, `foo.test.bar:-42|c|@0.5${metricsEnd}`);
+            assert.strictEqual(called, true);
             done();
           });
         });
@@ -314,12 +314,12 @@ describe('#statsFunctions', () => {
             statsd.decrement(['a', 'b'], 42, null, (error, bytes) => {
               called += 1;
               assert.ok(called === 1); // Ensure it only gets called once
-              assert.equal(error, null);
-              assert.equal(bytes, 0);
+              assert.strictEqual(error, null);
+              assert.strictEqual(bytes, 0);
             });
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, 'a:-42|c\nb:-42|c\n');
+            assert.strictEqual(metrics, 'a:-42|c\nb:-42|c\n');
             done();
           });
         });

--- a/test/timer.js
+++ b/test/timer.js
@@ -34,7 +34,7 @@ describe('#timer', () => {
         server.on('metrics', metrics => {
           // Search for a string similar to 'test:0.123|ms'
           const re = RegExp('(test:)([0-9]+.[0-9]+)\\|{1}(ms)');
-          assert.equal(true, re.test(metrics));
+          assert.strictEqual(true, re.test(metrics));
           done();
         });
       });
@@ -50,7 +50,7 @@ describe('#timer', () => {
         server.on('metrics', metrics => {
           // Search for a string similar to 'test:0.123|ms|#foo,bar'
           const re = RegExp('(test:)([0-9]+.[0-9]+)\\|{1}(ms)\\|{1}\\#(foo,bar)');
-          assert.equal(true, re.test(metrics));
+          assert.strictEqual(true, re.test(metrics));
           done();
         });
       });
@@ -83,7 +83,7 @@ describe('#timer', () => {
       const name = stat.split(/:|\|/)[0];
       const time = stat.split(/:|\|/)[1];
 
-      assert.equal(name, 'name-thingy');
+      assert.strictEqual(name, 'name-thingy');
       assert.ok(parseFloat(time) >= 99);
       assert.ok(parseFloat(time) < (100 + TIMER_BUFFER));
     });
@@ -103,7 +103,7 @@ describe('#timer', () => {
       const name = stat.split(/:|\|/)[0];
       const time = stat.split(/:|\|/)[1];
 
-      assert.equal(name, 'name-thingy');
+      assert.strictEqual(name, 'name-thingy');
       assert.ok(parseFloat(time) >= 99);
       assert.ok(parseFloat(time) < (100 + TIMER_BUFFER));
     });

--- a/test/udpDnsCacheTransport.js
+++ b/test/udpDnsCacheTransport.js
@@ -72,12 +72,12 @@ describe('#udpDnsCacheTransport', () => {
         };
 
         statsd.send('test title', {}, (error) => {
-          assert.equal(error, undefined);
+          assert.strictEqual(error, null);
           setTimeout(() => {
-            assert.equal(dnsLookupCount, 1);
-            assert.equal(socketMock.sendCount, 1);
-            assert.equal(socketMock.host, resolvedHostAddress);
-            assert.equal(socketMock.buf, 'test title');
+            assert.strictEqual(dnsLookupCount, 1);
+            assert.strictEqual(socketMock.sendCount, 1);
+            assert.strictEqual(socketMock.host, resolvedHostAddress);
+            assert.strictEqual(socketMock.buf.toString(), 'test title');
             done();
           }, 1000);
         });
@@ -102,15 +102,15 @@ describe('#udpDnsCacheTransport', () => {
         };
 
         statsd.send('message', {}, (error) => {
-          assert.equal(error, undefined);
+          assert.strictEqual(error, null);
         });
 
         statsd.send('other message', {}, (error) => {
-          assert.equal(error, undefined);
+          assert.strictEqual(error, null);
           setTimeout(() => {
-            assert.equal(dnsLookupCount, 1);
-            assert.equal(socketMock.sendCount, 2);
-            assert.equal(socketMock.host, resolvedHostAddress);
+            assert.strictEqual(dnsLookupCount, 1);
+            assert.strictEqual(socketMock.sendCount, 2);
+            assert.strictEqual(socketMock.host, resolvedHostAddress);
             done();
           }, 1000);
         });
@@ -137,19 +137,19 @@ describe('#udpDnsCacheTransport', () => {
         };
 
         statsd.send('message', {}, (error) => {
-          assert.equal(error, undefined);
+          assert.strictEqual(error, null);
         });
 
         statsd.send('other message', {}, (error) => {
-          assert.equal(error, undefined);
+          assert.strictEqual(error, null);
         });
 
         setTimeout(() => {
           statsd.send('message 1ms after TTL', {}, (error) => {
-            assert.equal(error, undefined);
+            assert.strictEqual(error, null);
             setTimeout(() => {
-              assert.equal(dnsLookupCount, 2);
-              assert.equal(socketMock.sendCount, 3);
+              assert.strictEqual(dnsLookupCount, 2);
+              assert.strictEqual(socketMock.sendCount, 3);
               done();
             }, 1000);
           });


### PR DESCRIPTION
fixes #185 


According to https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback, if the address provided is a hostname such as localhost, it will query DNS to resolve it. Setting 127.0.0.1 will avoid this DNS lookup when running the agent on localhost


**edit**: instead of hardcoding 127.0.0.1 we will go with leaving undefined.


According to dgram socket, if the address provided is a hostname such as
localhost, it will query DNS to resolve it. dns.lookup() has a fast path
for IP addresses, when omitting a value for host.

Also, from
https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback:

"If address is not provided or otherwise falsy, '127.0.0.1' (for udp4
sockets) or '::1' (for udp6 sockets) will be used by default."