### PR TITLE
Support multiple values for the same tag key

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -35,24 +35,27 @@ function overrideTags (parent, child, telegraf) {
     if (idx < 1) { // Not found or first character
       toAppend.push(tag);
     } else {
-      childCopy[tag.substring(0, idx)] = tag.substring(idx + 1);
+      const key = tag.substring(0, idx);
+      const value = tag.substring(idx + 1);
+      childCopy[key] = childCopy[key] || [];
+      childCopy[key].push(value);
     }
   });
-  const result = parent.map(tag => {
+  const result = parent.filter(tag => {
     const idx = typeof tag === 'string' ? tag.indexOf(':') : -1;
     if (idx < 1) { // Not found or first character
-      return tag;
+      return true;
     }
+
     const key = tag.substring(0, idx);
-    if (childCopy.hasOwnProperty(key)) {
-      const value = childCopy[key];
-      delete childCopy[key];
-      return `${key}:${value}`;
-    }
-    return tag;
+
+    return !childCopy.hasOwnProperty(key);
   });
+
   Object.keys(childCopy).forEach(key => {
-    result.push(`${key}:${childCopy[key]}`);
+    for (const value of childCopy[key]) {
+      result.push(`${key}:${value}`);
+    }
   });
   return result.concat(toAppend);
 }

--- a/test/childClient.js
+++ b/test/childClient.js
@@ -38,7 +38,7 @@ describe('#childClient', () => {
         assert.equal(child.prefix, 'preff.prefix');
         assert.equal(child.suffix, 'suffix.suff');
         assert.equal(statsd, global.statsd);
-        assert.deepEqual(child.globalTags, ['gtag', 'tag1:xxx', 'awesomeness:over9000', 'bar', ':baz']);
+        assert.deepEqual(child.globalTags, ['gtag', 'awesomeness:over9000', 'tag1:xxx', 'bar', ':baz']);
       });
     });
 

--- a/test/childClient.js
+++ b/test/childClient.js
@@ -38,7 +38,7 @@ describe('#childClient', () => {
         assert.strictEqual(child.prefix, 'preff.prefix');
         assert.strictEqual(child.suffix, 'suffix.suff');
         assert.strictEqual(statsd, global.statsd);
-        assert.deepEqual(child.globalTags, ['gtag', 'awesomeness:over9000', 'tag1:xxx', 'bar', ':baz'])
+        assert.deepEqual(child.globalTags, ['gtag', 'awesomeness:over9000', 'tag1:xxx', 'bar', ':baz']);
       });
     });
 

--- a/test/globalTags.js
+++ b/test/globalTags.js
@@ -60,12 +60,12 @@ describe('#globalTags', () => {
       it('should combine global tags and metric tags', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {
-            global_tags: ['gtag'],
+            global_tags: ['gtag:1', 'gtag:2', 'bar'],
           }), clientType);
           statsd.increment('test', 1337, ['foo']);
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#gtag,foo${metricEnd}`);
+          assert.equal(metrics, `test:1337|c|#gtag:1,gtag:2,bar,foo${metricEnd}`);
           done();
         });
       });
@@ -73,7 +73,7 @@ describe('#globalTags', () => {
       it('should override global tags with metric tags', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {
-            global_tags: ['foo', 'gtag:123'],
+            global_tags: ['foo', 'gtag:1', 'gtag:2'],
           }), clientType);
           statsd.increment('test', 1337, ['gtag:234', 'bar']);
         });
@@ -91,7 +91,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#gtag:234,foo:bar${metricEnd}`);
+          assert.equal(metrics, `test:1337|c|#foo:bar,gtag:234${metricEnd}`);
           done();
         });
       });
@@ -105,7 +105,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|~gtag:234,foo:bar${metricEnd}`);
+          assert.equal(metrics, `test:1337|c|~foo:bar,gtag:234${metricEnd}`);
           done();
         });
       });
@@ -119,7 +119,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|#gtag:234~foo:bar${metricEnd}`);
+          assert.equal(metrics, `test:1337|c|#foo:bar~gtag:234${metricEnd}`);
           done();
         });
       });
@@ -134,7 +134,7 @@ describe('#globalTags', () => {
           statsd.increment('test', 1337, { gtag: '234' });
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test:1337|c|~gtag:234~foo:bar${metricEnd}`);
+          assert.equal(metrics, `test:1337|c|~foo:bar~gtag:234${metricEnd}`);
           done();
         });
       });
@@ -155,13 +155,13 @@ describe('#globalTags', () => {
       it('should add global tags using telegraf format when enabled', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {
-            globalTags: ['gtag:gvalue', 'gtag2:gvalue2'],
+            globalTags: ['gtag:gvalue', 'gtag:gvalue2', 'gtag2:gvalue2'],
             telegraf: true,
           }), clientType);
           statsd.increment('test');
         });
         server.on('metrics', metrics => {
-          assert.equal(metrics, `test,gtag=gvalue,gtag2=gvalue2:1|c${metricEnd}`);
+          assert.equal(metrics, `test,gtag=gvalue,gtag=gvalue2,gtag2=gvalue2:1|c${metricEnd}`);
           done();
         });
       });

--- a/test/statsFunctions.js
+++ b/test/statsFunctions.js
@@ -38,10 +38,10 @@ describe('#statsFunctions', () => {
           it(`should send proper ${statFunction.name} format with tags`, done => {
             server = createServer(serverType, opts => {
               statsd = createHotShotsClient(opts, clientType);
-              statsd[statFunction.name]('test', 42, ['foo', 'bar']);
+              statsd[statFunction.name]('test', 42, ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
             });
             server.on('metrics', metrics => {
-              assert.equal(metrics, `test:42|${statFunction.unit}|#foo,bar${metricsEnd}`);
+              assert.equal(metrics, `test:42|${statFunction.unit}|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
               done();
             });
           });
@@ -172,10 +172,10 @@ describe('#statsFunctions', () => {
         it('should send proper count format with tags', done => {
           server = createServer(serverType, opts => {
             statsd = createHotShotsClient(opts, clientType);
-            statsd.increment('test', 42, ['foo', 'bar']);
+            statsd.increment('test', 42, ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:42|c|#foo,bar${metricsEnd}`);
+            assert.equal(metrics, `test:42|c|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -183,10 +183,10 @@ describe('#statsFunctions', () => {
         it('should send default count 1 with tags', done => {
           server = createServer(serverType, opts => {
             statsd = createHotShotsClient(opts, clientType);
-            statsd.increment('test', ['foo', 'bar']);
+            statsd.increment('test', ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:1|c|#foo,bar${metricsEnd}`);
+            assert.equal(metrics, `test:1|c|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -194,10 +194,10 @@ describe('#statsFunctions', () => {
         it('should send tags when sampleRate is omitted', done => {
           server = createServer(serverType, opts => {
             statsd = createHotShotsClient(opts, clientType);
-            statsd.increment('test', 23, ['foo', 'bar']);
+            statsd.increment('test', 23, ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:23|c|#foo,bar${metricsEnd}`);
+            assert.equal(metrics, `test:23|c|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -256,10 +256,10 @@ describe('#statsFunctions', () => {
         it('should send default count -1 with tags', done => {
           server = createServer(serverType, opts => {
             statsd = createHotShotsClient(opts, clientType);
-            statsd.decrement('test', ['foo', 'bar']);
+            statsd.decrement('test', ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-1|c|#foo,bar${metricsEnd}`);
+            assert.equal(metrics, `test:-1|c|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -267,10 +267,10 @@ describe('#statsFunctions', () => {
         it('should send tags when sampleRate is omitted', done => {
           server = createServer(serverType, opts => {
             statsd = createHotShotsClient(opts, clientType);
-            statsd.decrement('test', 23, ['foo', 'bar']);
+            statsd.decrement('test', 23, ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-23|c|#foo,bar${metricsEnd}`);
+            assert.equal(metrics, `test:-23|c|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
             done();
           });
         });
@@ -278,10 +278,10 @@ describe('#statsFunctions', () => {
         it('should send proper count format with tags', done => {
           server = createServer(serverType, opts => {
             statsd = createHotShotsClient(opts, clientType);
-            statsd.decrement('test', 42, ['foo', 'bar']);
+            statsd.decrement('test', 42, ['foo', 'bar', 'gtag:gvalue1', 'gtag:gvalue2']);
           });
           server.on('metrics', metrics => {
-            assert.equal(metrics, `test:-42|c|#foo,bar${metricsEnd}`);
+            assert.equal(metrics, `test:-42|c|#gtag:gvalue1,gtag:gvalue2,foo,bar${metricsEnd}`);
             done();
           });
         });


### PR DESCRIPTION
When doing `statsd.increment('someMetricName', 1, undefined, [key:value1, key:value2])`, it currently only send the `key:value2` tag to datadog, ignoring `key:value1`. I believe this is wrong and likely not intended, as DogStatsD supports it (I don't know about Etsy / Telegraf). This PR fixes that so that in the example above, both `key:value1` & `key:value2` will be sent to the StatsD server.