### PR TITLE
Fix uds reconnection logic

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -123,33 +123,26 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
     const socketCreateLimit = options.udsGracefulRestartRateLimit || UDS_DEFAULT_GRACEFUL_RESTART_LIMIT; // only recreate once per second
     const lastSocketCreateTime = Date.now();
     this.socket.on('error', (err) => {
-      const code = err.code;
-      switch (code) {
-        case 107:
-        case 111: {
-          if (Date.now() - lastSocketCreateTime >= socketCreateLimit) {
-            // recreate the socket, but only once per 30 seconds
-            if (this.errorHandler) {
-              this.socket.removeListener('error', this.errorHandler);
-            }
-            this.socket.close();
-            this.socket = createTransport(this, {
-              host: this.host,
-              path: options.path,
-              port: this.port,
-              protocol: this.protocol
-            });
-
-            if (this.errorHandler) {
-              this.socket.on('error', this.errorHandler);
-            } else {
-              this.socket.on('error', error => console.error(`hot-shots UDS error: ${error}`));
-            }
+      const code = util.getSystemErrorName(err.code);
+      if (code === 'ENOTCONN' || code === 'ECONNREFUSED') {
+        if (Date.now() - lastSocketCreateTime >= socketCreateLimit) {
+          // recreate the socket, but only once per 30 seconds
+          if (this.errorHandler) {
+            this.socket.removeListener('error', this.errorHandler);
           }
-          break;
-        }
-        default: {
-          break;
+          this.socket.close();
+          this.socket = createTransport(this, {
+            host: this.host,
+            path: options.path,
+            port: this.port,
+            protocol: this.protocol
+          });
+
+          if (this.errorHandler) {
+            this.socket.on('error', this.errorHandler);
+          } else {
+            this.socket.on('error', error => console.error(`hot-shots UDS error: ${error}`));
+          }
         }
       }
     });

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -179,12 +179,12 @@ describe('#errorHandling', () => {
       });
 
       if (serverType === 'uds' && clientType === 'client') {
-        it('should re-create the socket on 111 error for type uds', (done) => {
-          const code = 111;
+        it('should re-create the socket on -111 error for type uds', (done) => {
+          const code = -111;
           const realDateNow = Date.now;
           Date.now = () => '4857394578';
           // emit an error, like a socket would
-          // 111 is connection refused
+          // -111 is connection refused
           server = createServer('uds_broken', opts => {
             const client = statsd = createHotShotsClient(Object.assign(opts, {
               protocol: 'uds',
@@ -212,12 +212,12 @@ describe('#errorHandling', () => {
           });
         });
 
-        it('should re-create the socket on 107 error for type uds', (done) => {
-          const code = 107;
+        it('should re-create the socket on -107 error for type uds', (done) => {
+          const code = -107;
           const realDateNow = Date.now;
           Date.now = () => '4857394578';
           // emit an error, like a socket would
-          // 111 is connection refused
+          // -107 is transport endpoint not connected
           server = createServer('uds_broken', opts => {
             const client = statsd = createHotShotsClient(Object.assign(opts, {
               protocol: 'uds',
@@ -246,12 +246,12 @@ describe('#errorHandling', () => {
         });
 
         it('should re-create the socket on error for type uds with the configurable limit', (done) => {
-          const code = 111;
+          const code = -111;
           const limit = 4000;
           const realDateNow = Date.now;
           Date.now = () => '4857394578';
           // emit an error, like a socket would
-          // 111 is connection refused
+          // -111 is connection refused
           server = createServer('uds_broken', opts => {
             const client = statsd = createHotShotsClient(Object.assign(opts, {
               protocol: 'uds',
@@ -287,7 +287,7 @@ describe('#errorHandling', () => {
         });
 
         it('should not re-create the socket on error for type uds with udsGracefulErrorHandling set to false', (done) => {
-          const code = 111;
+          const code = -111;
           const realDateNow = Date.now;
           Date.now = () => '4857394578';
           // emit an error, like a socket would


### PR DESCRIPTION
Statsd UDS reconnection logic is not working because error code are checked against positive value : current codebase use the following  positive `errno` : 111 `ECONNREFUSED` & 107 `ENOTCONN`. 

However node.js relies on libuv that uses negated errno :
 * [description in libuv doc](https://docs.libuv.org/en/v1.x/errors.html)
 * [negated errno implementation logic](https://github.com/libuv/libuv/blob/v1.x/include/uv/errno.h#L25-L30)
 * [node.js doc referring to libuv](https://nodejs.org/api/errors.html#errors_error_errno)

This PR uses `util.getSystemErrorName` that was made available in [node.js v9.7.0](https://nodejs.org/api/util.html#util_util_getsystemerrorname_err) and subsequently [backported to v8.12.0](https://nodejs.org/fr/blog/release/v8.12.0/)

Either it's acceptable to bump the node.js version requirements from "Node 8.x and higher" to "Node 8.12 and higher" or we can go back to the hardcoded number and just negate those (side notes: those codes does not exit on mac and are different on windows, -4053 and -4078 thus resolving to the text representation will be more platform agnostic) just let me know !





