### PR TITLE
Add gaugeDelta function

### DIFF
--- a/lib/statsFunctions.js
+++ b/lib/statsFunctions.js
@@ -187,7 +187,6 @@ function applyStatsFns (Client) {
     this.sendAll(stat, value, 'd', sampleRate, tags, callback);
   };
 
-
   /**
    * Gauges a stat by a specified amount
    * @param stat {String|Array} The stat(s) to send
@@ -198,6 +197,19 @@ function applyStatsFns (Client) {
    */
   Client.prototype.gauge = function (stat, value, sampleRate, tags, callback) {
     this.sendAll(stat, value, 'g', sampleRate, tags, callback);
+  };
+
+  /**
+   * Gauges a stat by a delta
+   * @param stat {String|Array} The stat(s) to send
+   * @param value The value to send
+   * @param sampleRate {Number=} The Number of times to sample (0 to 1). Optional.
+   * @param tags {Array=} The Array of tags to add to metrics. Optional.
+   * @param callback {Function=} Callback when message is done being delivered. Optional.
+   */
+  Client.prototype.gaugeDelta = function (stat, value, sampleRate, tags, callback) {
+    const sign = value >= 0 ? '+' : '-';
+    this.sendAll(stat, `${sign}${value}`, 'g', sampleRate, tags, callback);
   };
 
   /**

--- a/test/statsFunctions.js
+++ b/test/statsFunctions.js
@@ -20,6 +20,7 @@ describe('#statsFunctions', () => {
       { name: 'histogram', unit: 'h', bytes: 12 },
       { name: 'distribution', unit: 'd', bytes: 12 },
       { name: 'gauge', unit: 'g', bytes: 12 },
+      { name: 'gaugeDelta', unit: 'g', bytes: 12 },
       { name: 'set', unit: 's', bytes: 12 },
       ].forEach(statFunction => {
 


### PR DESCRIPTION
Hi! We had the need to use a gauge with incremental og decremental deltas the other day, I found out `hot-shots` do not have support for it, but it can be done with the `#send` method, so I figured I would add a pull request for the feature, it's based on how [statsd-client does it](https://github.com/msiebuhr/node-statsd-client/blob/master/lib/statsd-client.js#L63) (well heavily copied :)).

However, I am not sure how to write the tests for this function. I could add another key to the statFunction test array, perhaps like this:

```js
{ name: 'gaugeDelta', unit: 'g', bytes: 12, prefix: '+' },
{ name: 'gaugeDelta', unit: 'g', bytes: 12, prefix: '-' }
```

What do you think? I wanted to get your input before going ahead and changing the tests