### PR TITLE
always emit error on socket after unsuccessful send

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -354,9 +354,11 @@ Client.prototype.sendMessage = function (message, callback) {
         this.errorHandler(errFormatted);
       } else {
         console.error(String(errFormatted));
-        // emit error ourselves on the socket for backwards compatibility
-        this.socket.emit('error', errFormatted);
       }
+    }
+    if (errFormatted) {
+      // emit error ourselves on the socket for backwards compatibility
+      this.socket.emit('error', errFormatted);
     }
   };
 


### PR DESCRIPTION
Emit error after send failure in all cases (callback, custom error handler, default error handler) as opposed to only on default error handler