### PR TITLE
Make close callback optional in TypeScript definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -130,7 +130,7 @@ declare module "hot-shots" {
     unique(stat: string | string[], value: number | string, callback?: StatsCb): void;
     unique(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
 
-    close(callback: (error?: Error) => void): void;
+    close(callback?: (error?: Error) => void): void;
 
     event(title: string, text?: string, options?: EventOptions, tags?: Tags, callback?: StatsCb): void;
     event(title: string, text?: string, options?: EventOptions, callback?: StatsCb): void;


### PR DESCRIPTION
This patch makes the callback to `StatsD#close()` optional in the TypeScript definitions.