### PR TITLE
Handle UDS errors occurring when sending metrics

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -345,6 +345,8 @@ Client.prototype.sendMessage = function (message, callback) {
     const errFormatted = err ? new Error(`Error sending hot-shots message: ${err}`) : null;
     if (errFormatted) {
       errFormatted.code = err.code;
+      // handle UDS error that requires socket replacement when we are not
+      // emitting the `error` event on `this.socket`
       if (this.protocol === PROTOCOL.UDS && (callback || this.errorHandler)) {
         udsErrorHandler(this, err);
       }
@@ -506,7 +508,7 @@ exports = module.exports = Client;
 exports.StatsD = Client;
 
 /**
- * Handle an error connecting to a Unix Domain Socket (UDS). This will
+ * Detect and handle an error connecting to a Unix Domain Socket (UDS). This will
  * attempt to create a new socket and replace and close the client's current
  * socket, registering a **new** `udsErrorHandler()` on the newly created socket.
  * If a new socket can't be created (e.g. if no UDS currently exists at
@@ -571,7 +573,8 @@ function maybeAddUDSErrorHandler(client) {
 
 /**
  * Try to replace a client's socket with a new transport. If `createTransport()`
- * returns `null` this will still set the client's socket to `null`.
+ * returns `null` this will still set the client's socket to `null`. This also
+ * updates the socket creation time for UDS error handling.
  * @param client Client The statsd Client that will be getting a new socket
  */
 function trySetNewSocket(client) {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -525,8 +525,8 @@ function udsErrorHandler(client, err) {
   }
 
   // recreate the socket, but only once within `udsGracefulRestartRateLimit`.
-  if (!client.lastSocketCreateTime ||
-    Date.now() - client.lastSocketCreateTime < client.udsGracefulRestartRateLimit) {
+  if (!client.socket.createdAt ||
+    Date.now() - client.socket.createdAt < client.udsGracefulRestartRateLimit) {
     return;
   }
 
@@ -543,7 +543,6 @@ function udsErrorHandler(client, err) {
   if (newSocket) {
     client.socket.close();
     client.socket = newSocket;
-    client.lastSocketCreateTime = Date.now();
     maybeAddUDSErrorHandler(client);
   } else {
     console.error('Could not replace UDS connection with new socket');
@@ -589,5 +588,4 @@ function trySetNewSocket(client) {
     protocol: client.protocol,
     stream: client.stream,
   });
-  client.lastSocketCreateTime = Date.now();
 }

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -63,7 +63,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   if (process.env.DD_ENTITY_ID) {
     this.globalTags = this.globalTags.filter((item) => {
       return item.indexOf('dd.internal.entity_id:') !== 0;
-   });
+    });
     this.globalTags.push('dd.internal.entity_id:'.concat(helpers.sanitizeTags(process.env.DD_ENTITY_ID)));
   }
   this.telegraf = options.telegraf || false;
@@ -119,8 +119,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   // options.udsGracefulRestartRateLimit is the minimum time (ms) between creating sockets
   // does not support options.isChild (how to re-create a socket you didn't create?)
   if (this.socket && options.protocol === PROTOCOL.UDS) {
-    const lastSocketCreateTime = Date.now();
-    maybeAddUDSErrorHandler(this, lastSocketCreateTime);
+    maybeAddUDSErrorHandler(this);
   }
 
   this.messagesInFlight = 0;
@@ -346,6 +345,9 @@ Client.prototype.sendMessage = function (message, callback) {
     const errFormatted = err ? new Error(`Error sending hot-shots message: ${err}`) : null;
     if (errFormatted) {
       errFormatted.code = err.code;
+      if (this.protocol === PROTOCOL.UDS && (callback || this.errorHandler)) {
+        udsErrorHandler(this, err);
+      }
     }
     if (callback) {
       callback(errFormatted, bytes);
@@ -513,12 +515,14 @@ exports.StatsD = Client;
  * Note that this will no-op with an early exit if the last socket create time
  * was too recent (within the UDS graceful restart rate limit).
  * @param client Client The statsd Client that may be getting a UDS error handler.
- * @param lastSocketCreateTime number The timestamp (in milliseconds since the
- *        epoch) when the current socket was created.
  */
-function udsErrorHandler(client, lastSocketCreateTime) {
+function udsErrorHandler(client, err) {
+  if (!err || !UDS_ERROR_CODES.includes(-err.code)) {
+    return;
+  }
+
   // recreate the socket, but only once within `udsGracefulRestartRateLimit`.
-  if (Date.now() - lastSocketCreateTime < client.udsGracefulRestartRateLimit) {
+  if (Date.now() - client.lastSocketCreateTime < client.udsGracefulRestartRateLimit) {
     return;
   }
 
@@ -535,7 +539,8 @@ function udsErrorHandler(client, lastSocketCreateTime) {
   if (newSocket) {
     client.socket.close();
     client.socket = newSocket;
-    maybeAddUDSErrorHandler(client, Date.now());
+    client.lastSocketCreateTime = Date.now();
+    maybeAddUDSErrorHandler(client);
   } else {
     console.error('Could not replace UDS connection with new socket');
     return;
@@ -553,18 +558,14 @@ function udsErrorHandler(client, lastSocketCreateTime) {
  * client is not a "child" client and has graceful error handling enabled for
  * UDS.
  * @param client Client The statsd Client that may be getting a UDS error handler.
- * @param lastSocketCreateTime number The timestamp (in milliseconds since the
- *        epoch) when the current socket was created.
  */
-function maybeAddUDSErrorHandler(client, lastSocketCreateTime) {
+function maybeAddUDSErrorHandler(client) {
   if (client.isChild || !client.udsGracefulErrorHandling) {
     return;
   }
 
   client.socket.on('error', (err) => {
-    if (UDS_ERROR_CODES.includes(-err.code)) {
-      udsErrorHandler(client, lastSocketCreateTime);
-    }
+    udsErrorHandler(client, err);
   });
 }
 
@@ -583,4 +584,5 @@ function trySetNewSocket(client) {
     protocol: client.protocol,
     stream: client.stream,
   });
+  client.lastSocketCreateTime = Date.now();
 }

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -517,6 +517,7 @@ exports.StatsD = Client;
  * Note that this will no-op with an early exit if the last socket create time
  * was too recent (within the UDS graceful restart rate limit).
  * @param client Client The statsd Client that may be getting a UDS error handler.
+ * @param err The error that we will handle if a UDS connection error is detected.
  */
 function udsErrorHandler(client, err) {
   if (!err || !UDS_ERROR_CODES.includes(-err.code)) {
@@ -524,7 +525,8 @@ function udsErrorHandler(client, err) {
   }
 
   // recreate the socket, but only once within `udsGracefulRestartRateLimit`.
-  if (Date.now() - client.lastSocketCreateTime < client.udsGracefulRestartRateLimit) {
+  if (!client.lastSocketCreateTime ||
+    Date.now() - client.lastSocketCreateTime < client.udsGracefulRestartRateLimit) {
     return;
   }
 

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -158,6 +158,7 @@ module.exports = (instance, args) => {
       throw new Error(`Unsupported protocol '${protocol}'`);
     }
     transport.type = protocol;
+    transport.createdAt = Date.now();
   } catch (e) {
     if (instance.errorHandler) {
       instance.errorHandler(e);

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -181,214 +181,211 @@ describe('#errorHandling', () => {
       });
 
       if (serverType === 'uds' && clientType === 'client') {
-        it('should re-create the socket on bad connection error for type uds', (done) => {
-          const code = badUDSConnectionCode();
+        describe('#udsSocket', () => {
           const realDateNow = Date.now;
-          Date.now = () => '4857394578';
-          // emit an error, like a socket would
-          server = createServer('uds_broken', opts => {
-            const client = statsd = createHotShotsClient(Object.assign(opts, {
-              protocol: 'uds',
-              errorHandler(error) {
-                assert.ok(error);
-                assert.strictEqual(error.code, code);
-              }
-            }), 'client');
-            const initialSocket = client.socket;
-            setTimeout(() => {
-              initialSocket.emit('error', { code });
-              assert.ok(Object.is(initialSocket, client.socket));
-              // it should not create the socket if it breaks too quickly
-              // change time and make another error
-              Date.now = () => 4857394578 + 1000; // 1 second later
-              initialSocket.emit('error', { code });
+          afterEach(() => {
+            // put things back
+            Date.now = realDateNow;
+          })
+          it('should re-create the socket on bad connection error for type uds', (done) => {
+            const code = badUDSConnectionCode();
+            const realDateNow = Date.now;
+            Date.now = () => '4857394578';
+            // emit an error, like a socket would
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
               setTimeout(() => {
-                // make sure the socket was re-created
-                assert.notEqual(initialSocket, client.socket);
-                // put things back
-                Date.now = realDateNow;
-                done();
-              }, 5);
-            }, 5);
-          });
-        });
-
-        it('should re-create the socket on bad descriptor error for type uds', (done) => {
-          const code = badUDSDescriptorCode();
-          const realDateNow = Date.now;
-          Date.now = () => '4857394578';
-          // emit an error, like a socket would
-          server = createServer('uds_broken', opts => {
-            const client = statsd = createHotShotsClient(Object.assign(opts, {
-              protocol: 'uds',
-              errorHandler(error) {
-                assert.ok(error);
-                assert.strictEqual(error.code, code);
-              }
-            }), 'client');
-            const initialSocket = client.socket;
-            setTimeout(() => {
-              initialSocket.emit('error', { code });
-              assert.ok(Object.is(initialSocket, client.socket));
-              // it should not create the socket if it breaks too quickly
-              // change time and make another error
-              Date.now = () => 4857394578 + 1000; // 1 second later
-              initialSocket.emit('error', { code });
-              setTimeout(() => {
-                // make sure the socket was re-created
-                assert.notEqual(initialSocket, client.socket);
-                // put things back
-                Date.now = realDateNow;
-                done();
-              }, 5);
-            }, 5);
-          });
-        });
-
-        it('should re-create the socket on error for type uds with the configurable limit', (done) => {
-          const code = badUDSConnectionCode();
-          const limit = 4000;
-          const realDateNow = Date.now;
-          Date.now = () => '4857394578';
-          // emit an error, like a socket would
-          server = createServer('uds_broken', opts => {
-            const client = statsd = createHotShotsClient(Object.assign(opts, {
-              protocol: 'uds',
-              udsGracefulRestartRateLimit: limit,
-              errorHandler(error) {
-                assert.ok(error);
-                assert.strictEqual(error.code, code);
-              }
-            }), 'client');
-            const initialSocket = client.socket;
-            setTimeout(() => {
-              initialSocket.emit('error', { code });
-              assert.ok(Object.is(initialSocket, client.socket));
-              // it should not create the socket if it breaks too quickly
-              // change time and make another error
-              Date.now = () => 4857394578 + 1000; // 1 second later
-              initialSocket.emit('error', { code });
-              setTimeout(() => {
-                // make sure the socket was NOT re-created
-                assert.strictEqual(initialSocket, client.socket);
-                Date.now = () => 4857394578 + limit; // 1 second later
                 initialSocket.emit('error', { code });
-                setTimeout(() => {
-                  // make sure the socket was re-created
-                  assert.notEqual(initialSocket, client.socket);
-                  // put things back
-                  Date.now = realDateNow;
-                  done();
-                }, 5);
-              }, 5);
-            }, 5);
-          });
-        });
-
-        it('should re-create the socket on bad descriptor error when sending metric', (done) => {
-          const code = badUDSDescriptorCode();
-          const realDateNow = Date.now;
-          Date.now = () => '4857394578';
-          // emit an error, like a socket would
-          server = createServer('uds_broken', opts => {
-            const client = statsd = createHotShotsClient(Object.assign(opts, {
-              protocol: 'uds',
-              errorHandler(error) {
-                assert.ok(error);
-                assert.strictEqual(error.code, code);
-              }
-            }), 'client');
-            const initialSocket = client.socket;
-            client.socket.send = function (_, callback) {
-              callback({ code })
-            };
-            setTimeout(() => {
-              client.increment('metric.name');
-              assert.ok(Object.is(initialSocket, client.socket));
-              // it should not create the socket if it breaks too quickly
-              // change time and make another error
-              Date.now = () => 4857394578 + 1000; // 1 second later
-              client.increment('metric.name');
-              setTimeout(() => {
-                // make sure the socket was re-created
-                assert.notEqual(initialSocket, client.socket);
-                // put things back
-                Date.now = realDateNow;
-                done();
-              }, 5);
-            }, 5);
-          });
-        });
-
-        it('should re-create the socket on bad descriptor error when sending metric with a callback', (done) => {
-          const code = badUDSDescriptorCode();
-          const realDateNow = Date.now;
-          Date.now = () => '4857394578';
-          // emit an error, like a socket would
-          server = createServer('uds_broken', opts => {
-            const client = statsd = createHotShotsClient(Object.assign(opts, {
-              protocol: 'uds',
-              errorHandler(error) {
-                assert.ok(error);
-                assert.strictEqual(error.code, code);
-              }
-            }), 'client');
-            const initialSocket = client.socket;
-            client.socket.send = function (_, callback) {
-              callback({ code })
-            };
-            setTimeout(() => {
-              client.increment('metric.name', (error) => {
-                assert.strictEqual(error.code, code);
                 assert.ok(Object.is(initialSocket, client.socket));
                 // it should not create the socket if it breaks too quickly
                 // change time and make another error
                 Date.now = () => 4857394578 + 1000; // 1 second later
-                client.increment('metric.name', (error) => {
-                  assert.strictEqual(error.code, code)
+                initialSocket.emit('error', { code });
+                setTimeout(() => {
+                  // make sure the socket was re-created
+                  assert.notEqual(initialSocket, client.socket);
+                  done();
+                }, 5);
+              }, 5);
+            });
+          });
+
+          it('should re-create the socket on bad descriptor error for type uds', (done) => {
+            const code = badUDSDescriptorCode();
+            const realDateNow = Date.now;
+            Date.now = () => '4857394578';
+            // emit an error, like a socket would
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
+              setTimeout(() => {
+                initialSocket.emit('error', { code });
+                assert.ok(Object.is(initialSocket, client.socket));
+                // it should not create the socket if it breaks too quickly
+                // change time and make another error
+                Date.now = () => 4857394578 + 1000; // 1 second later
+                initialSocket.emit('error', { code });
+                setTimeout(() => {
+                  // make sure the socket was re-created
+                  assert.notEqual(initialSocket, client.socket);
+                  done();
+                }, 5);
+              }, 5);
+            });
+          });
+
+          it('should re-create the socket on error for type uds with the configurable limit', (done) => {
+            const code = badUDSConnectionCode();
+            const limit = 4000;
+            const realDateNow = Date.now;
+            Date.now = () => '4857394578';
+            // emit an error, like a socket would
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                udsGracefulRestartRateLimit: limit,
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
+              setTimeout(() => {
+                initialSocket.emit('error', { code });
+                assert.ok(Object.is(initialSocket, client.socket));
+                // it should not create the socket if it breaks too quickly
+                // change time and make another error
+                Date.now = () => 4857394578 + 1000; // 1 second later
+                initialSocket.emit('error', { code });
+                setTimeout(() => {
+                  // make sure the socket was NOT re-created
+                  assert.strictEqual(initialSocket, client.socket);
+                  Date.now = () => 4857394578 + limit; // 1 second later
+                  initialSocket.emit('error', { code });
                   setTimeout(() => {
                     // make sure the socket was re-created
                     assert.notEqual(initialSocket, client.socket);
-                    // put things back
-                    Date.now = realDateNow;
                     done();
                   }, 5);
-                });
-              });
-            }, 5);
-          });
-        });
-
-        it('should not re-create the socket on error for type uds with udsGracefulErrorHandling set to false', (done) => {
-          const code = badUDSConnectionCode();
-          const realDateNow = Date.now;
-          Date.now = () => '4857394578';
-          // emit an error, like a socket would
-          server = createServer('uds_broken', opts => {
-            const client = statsd = createHotShotsClient(Object.assign(opts, {
-              protocol: 'uds',
-              udsGracefulErrorHandling: false,
-              errorHandler(error) {
-                assert.ok(error);
-                assert.strictEqual(error.code, code);
-              }
-            }), 'client');
-            const initialSocket = client.socket;
-            setTimeout(() => {
-              initialSocket.emit('error', { code });
-              assert.ok(Object.is(initialSocket, client.socket));
-              // it should not create the socket anyway if it breaks too quickly
-              // change time and make another error
-              Date.now = () => 4857394578 + 1000; // 1 second later
-              initialSocket.emit('error', { code });
-              setTimeout(() => {
-                // make sure the socket was NOT re-created
-                assert.strictEqual(initialSocket, client.socket);
-                // put things back
-                Date.now = realDateNow;
-                done();
+                }, 5);
               }, 5);
-            }, 5);
+            });
+          });
+
+          it('should re-create the socket on bad descriptor error when sending metric', (done) => {
+            const code = badUDSDescriptorCode();
+            const realDateNow = Date.now;
+            Date.now = () => '4857394578';
+            // emit an error, like a socket would
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
+              // mock send function on the initial socket
+              initialSocket.send = function (_, callback) {
+                callback({ code })
+              };
+              setTimeout(() => {
+                client.increment('metric.name');
+                assert.ok(Object.is(initialSocket, client.socket));
+                // it should not create the socket if it breaks too quickly
+                // change time and make another error
+                Date.now = () => 4857394578 + 1000; // 1 second later
+                client.increment('metric.name');
+                setTimeout(() => {
+                  // make sure the socket was re-created
+                  assert.notEqual(initialSocket, client.socket);
+                  done();
+                }, 5);
+              }, 5);
+            });
+          });
+
+          it('should re-create the socket on bad descriptor error when sending metric with a callback', (done) => {
+            const code = badUDSDescriptorCode();
+            const realDateNow = Date.now;
+            Date.now = () => '4857394578';
+            // emit an error, like a socket would
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
+              // mock send function on the initial socket
+              initialSocket.send = function (_, callback) {
+                callback({ code })
+              };
+              setTimeout(() => {
+                client.increment('metric.name', (error) => {
+                  assert.strictEqual(error.code, code);
+                  assert.ok(Object.is(initialSocket, client.socket));
+                  // it should not create the socket if it breaks too quickly
+                  // change time and make another error
+                  Date.now = () => 4857394578 + 1000; // 1 second later
+                  client.increment('metric.name', (error) => {
+                    assert.strictEqual(error.code, code)
+                    setTimeout(() => {
+                      // make sure the socket was re-created
+                      assert.notEqual(initialSocket, client.socket);
+                      done();
+                    }, 5);
+                  });
+                });
+              }, 5);
+            });
+          });
+
+          it('should not re-create the socket on error for type uds with udsGracefulErrorHandling set to false', (done) => {
+            const code = badUDSConnectionCode();
+            const realDateNow = Date.now;
+            Date.now = () => '4857394578';
+            // emit an error, like a socket would
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                udsGracefulErrorHandling: false,
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
+              setTimeout(() => {
+                initialSocket.emit('error', { code });
+                assert.ok(Object.is(initialSocket, client.socket));
+                // it should not create the socket anyway if it breaks too quickly
+                // change time and make another error
+                Date.now = () => 4857394578 + 1000; // 1 second later
+                initialSocket.emit('error', { code });
+                setTimeout(() => {
+                  // make sure the socket was NOT re-created
+                  assert.strictEqual(initialSocket, client.socket);
+                  done();
+                }, 5);
+              }, 5);
+            });
           });
         });
       }

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -187,7 +187,7 @@ describe('#errorHandling', () => {
           const realDateNow = Date.now;
           afterEach(() => {
             Date.now = realDateNow;
-          })
+          });
 
           it('should re-create the socket on bad connection error for type uds', (done) => {
             const code = badUDSConnectionCode();

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -182,14 +182,15 @@ describe('#errorHandling', () => {
 
       if (serverType === 'uds' && clientType === 'client') {
         describe('#udsSocket', () => {
+
+          // ensure we restore the original `Date.now` after each test
           const realDateNow = Date.now;
           afterEach(() => {
-            // put things back
             Date.now = realDateNow;
           })
+
           it('should re-create the socket on bad connection error for type uds', (done) => {
             const code = badUDSConnectionCode();
-            const realDateNow = Date.now;
             Date.now = () => '4857394578';
             // emit an error, like a socket would
             server = createServer('uds_broken', opts => {
@@ -219,7 +220,6 @@ describe('#errorHandling', () => {
 
           it('should re-create the socket on bad descriptor error for type uds', (done) => {
             const code = badUDSDescriptorCode();
-            const realDateNow = Date.now;
             Date.now = () => '4857394578';
             // emit an error, like a socket would
             server = createServer('uds_broken', opts => {
@@ -250,7 +250,6 @@ describe('#errorHandling', () => {
           it('should re-create the socket on error for type uds with the configurable limit', (done) => {
             const code = badUDSConnectionCode();
             const limit = 4000;
-            const realDateNow = Date.now;
             Date.now = () => '4857394578';
             // emit an error, like a socket would
             server = createServer('uds_broken', opts => {
@@ -287,7 +286,6 @@ describe('#errorHandling', () => {
 
           it('should re-create the socket on bad descriptor error when sending metric', (done) => {
             const code = badUDSDescriptorCode();
-            const realDateNow = Date.now;
             Date.now = () => '4857394578';
             // emit an error, like a socket would
             server = createServer('uds_broken', opts => {
@@ -321,7 +319,6 @@ describe('#errorHandling', () => {
 
           it('should re-create the socket on bad descriptor error when sending metric with a callback', (done) => {
             const code = badUDSDescriptorCode();
-            const realDateNow = Date.now;
             Date.now = () => '4857394578';
             // emit an error, like a socket would
             server = createServer('uds_broken', opts => {
@@ -359,7 +356,6 @@ describe('#errorHandling', () => {
 
           it('should not re-create the socket on error for type uds with udsGracefulErrorHandling set to false', (done) => {
             const code = badUDSConnectionCode();
-            const realDateNow = Date.now;
             Date.now = () => '4857394578';
             // emit an error, like a socket would
             server = createServer('uds_broken', opts => {

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -298,7 +298,7 @@ describe('#errorHandling', () => {
               }), 'client');
               const initialSocket = client.socket;
               // mock send function on the initial socket
-              initialSocket.send = function (_, callback) {
+              initialSocket.send = (_, callback) => {
                 callback({ code });
               };
               setTimeout(() => {
@@ -331,7 +331,7 @@ describe('#errorHandling', () => {
               }), 'client');
               const initialSocket = client.socket;
               // mock send function on the initial socket
-              initialSocket.send = function (_, callback) {
+              initialSocket.send = (_, callback) => {
                 callback({ code });
               };
               setTimeout(() => {

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -299,7 +299,7 @@ describe('#errorHandling', () => {
               const initialSocket = client.socket;
               // mock send function on the initial socket
               initialSocket.send = function (_, callback) {
-                callback({ code })
+                callback({ code });
               };
               setTimeout(() => {
                 client.increment('metric.name');
@@ -332,17 +332,17 @@ describe('#errorHandling', () => {
               const initialSocket = client.socket;
               // mock send function on the initial socket
               initialSocket.send = function (_, callback) {
-                callback({ code })
+                callback({ code });
               };
               setTimeout(() => {
-                client.increment('metric.name', (error) => {
+                client.increment('metric.name', error => {
                   assert.strictEqual(error.code, code);
                   assert.ok(Object.is(initialSocket, client.socket));
                   // it should not create the socket if it breaks too quickly
                   // change time and make another error
                   Date.now = () => 4857394578 + 1000; // 1 second later
-                  client.increment('metric.name', (error) => {
-                    assert.strictEqual(error.code, code)
+                  client.increment('metric.name', anotherError => {
+                    assert.strictEqual(anotherError.code, code);
                     setTimeout(() => {
                       // make sure the socket was re-created
                       assert.notEqual(initialSocket, client.socket);


### PR DESCRIPTION
The UDS error handling added in #189 only triggers when an `error` event is emitted on the current socket instance. When the client encounters an error from sending a message, it does not send an error event to the underlying socket if the callback or the `errorHandler` option is supplied. I have been able to reproduce the issue with the following steps.

1. Start up a DogStatsD server that listens on a UDS.  (I used https://github.com/dhermes/local-dd-agent.)
2. Point the `hot-shots` client to the socket path with a custom `errorHandler`. Periodically sending a metric with `setInterval`.
3. Stop the server.
4. The client should start triggering the `errorHandler` with a UDS error.
5. Start the server which would recreates the socket file.
6. The client cannot reconnect to the socket path and sending metrics still triggers the `errorHandler`. I expect the client to be able to reconnect after the DogStatsD server is back online.

This PR adds UDS error handling for such case by calling `udsErrorHandler()` directly. The `lastSocketCreateTime` field is added to the client to allow calling the function outside the scope that the socket is created.

I also added two test cases to represent the issue this PR is trying to solve.