### PR TITLE
Fix formatDate ignoring number primitives

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -68,7 +68,7 @@ function formatDate(date) {
   if (date instanceof Date) {
     // Datadog expects seconds.
     timestamp = Math.round(date.getTime() / 1000);
-  } else if (date instanceof Number) {
+  } else if (date instanceof Number || typeof date === 'number') {
     // Make sure it is an integer, not a float.
     timestamp = Math.round(date);
   }

--- a/test/event.js
+++ b/test/event.js
@@ -59,6 +59,28 @@ describe('#event', () => {
         });
       });
 
+      it('should send proper event format for title, text, and options for primitive dates', done => {
+        const date = Math.round(Date.now() / 1000);
+        const dateAsDate = new Date(date);
+        server = createServer(serverType, opts => {
+          statsd = createHotShotsClient(opts, clientType);
+          const options = {
+            date_happened: date,
+            hostname: 'host',
+            aggregation_key: 'ag_key',
+            priority: 'low',
+            source_type_name: 'source_type',
+            alert_type: 'warning'
+          };
+          statsd.event('test title', 'another\nmultiline\ndescription', options);
+        });
+        server.on('metrics', event => {
+          assert.strictEqual(event, `_e{10,31}:test title|another\\nmultiline\\ndescription|d:${dateAsDate.getTime()}|h:host|k:ag_key|p:low|s:source_type|t:warning${metricEnd}`
+          );
+          done();
+        });
+      });
+
       it('should send proper event format for title, text, some options, and tags', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(opts, clientType);


### PR DESCRIPTION
`formatDate` currently returns `undefined` when you pass it a primitive number since `1 instanceof Number === false`. This will fix it so it detects both Number objects and primitive numbers.