### PR TITLE
Use error handler on UDS socket replace error.

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -545,7 +545,12 @@ function udsErrorHandler(client, err) {
     client.socket = newSocket;
     maybeAddUDSErrorHandler(client);
   } else {
-    console.error('Could not replace UDS connection with new socket');
+    const errorMessage = 'Could not replace UDS connection with new socket';
+    if (client.errorHandler) {
+      client.errorHandler(new Error(errorMessage));
+    } else {
+      console.error(errorMessage);
+    }
     return;
   }
 


### PR DESCRIPTION
Hey! I have an app that uses its own logger and sends hot-shots logs to a separate stream (not stderr). That mostly works, except for error `'Could not replace UDS connection with new socket'`, which is not using the client error handler.

This seems like a simple oversight, since just a few lines below this error is generated, other errors are either passed to the client's handler or just `console.error`ed. If it really was just an oversight, this patch should fix it.

If instead it was intentional to not trigger the client's error handler on these errors, I wonder if I could send a PR to allow providing a custom logger to the client? (Just an object with log/error methods, like what several other clients do).