### PR TITLE
Add a closingFlushInterval option which allows stopping StatsD quicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Parameters (specified as one object passed into hot-shots):
 * `stream`: Reference to a stream instance. Used only when the protocol is `stream`.
 * `udsGracefulErrorHandling`: Used only when the protocol is `uds`. Boolean indicating whether to handle socket errors gracefully. Defaults to true.
 * `udsGracefulRestartRateLimit`: Used only when the protocol is `uds`. Time (ms) between re-creating the socket. Defaults to `1000`.
+* `closingFlushInterval`: Before closing, StatsD will check for inflight messages. Time (ms) between each check. Defaults to `50`.
 
 ### StatsD methods
 All StatsD methods other than `event`, `close`, and `check` have the same API:

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -75,6 +75,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.udsGracefulErrorHandling = 'udsGracefulErrorHandling' in options ? options.udsGracefulErrorHandling : true;
   this.udsGracefulRestartRateLimit = options.udsGracefulRestartRateLimit || UDS_DEFAULT_GRACEFUL_RESTART_LIMIT; // only recreate once per second
   this.isChild = options.isChild;
+  this.closingFlushInterval = options.closingFlushInterval || 50;
 
   // If we're mocking the client, create a buffer to record the outgoing calls.
   if (this.mock) {
@@ -413,7 +414,7 @@ Client.prototype.close = function (callback) {
         clearInterval(waitForMessages);
         this._close(callback);
       }
-    }, 50);
+    }, this.closingFlushInterval);
   });
 };
 
@@ -488,7 +489,8 @@ const ChildClient = function (parent, options) {
     maxBufferSize : parent.maxBufferSize,
     bufferFlushInterval: parent.bufferFlushInterval,
     telegraf    : parent.telegraf,
-    protocol    : parent.protocol
+    protocol    : parent.protocol,
+    closingFlushInterval : parent.closingFlushInterval
   });
 };
 util.inherits(ChildClient, Client);

--- a/test/init.js
+++ b/test/init.js
@@ -201,6 +201,18 @@ describe('#init', () => {
     skipClose = true;
   });
 
+  it('should set the closingFlushInterval option with the provided value', () => {
+    statsd = createHotShotsClient({
+      closingFlushInterval: 10
+    }, clientType);
+    assert.strictEqual(statsd.closingFlushInterval, 10);
+  });
+
+  it('should set the closingFlushInterval option with the default value', () => {
+    statsd = createHotShotsClient({}, clientType);
+    assert.strictEqual(statsd.closingFlushInterval, 50);
+  });
+
   it('should create a socket variable that is an instance of net.Socket if set to TCP', done => {
     server = createServer('tcp', opts => {
       statsd = createHotShotsClient(opts, clientType);

--- a/types.d.ts
+++ b/types.d.ts
@@ -27,6 +27,7 @@ declare module "hot-shots" {
     tagSeparator?: string;
     udsGracefulErrorHandling?: boolean;
     udsGracefulRestartRateLimit?: number;
+    closingFlushInterval?: number;
   }
 
   export interface ChildClientOptions {


### PR DESCRIPTION
👋  Team !

When `close` is called, we need to wait at least 50ms. This could be quite long in a time-constraint environment such as an AWS Lambda function.

This PR adds a simple option to customize this parameter, defaulting to the current value : 50ms which is fully backward-compatible.

Let me know what do you think! 🙏 