### PR TITLE
fix(types): add stream to protocol string union type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -17,7 +17,7 @@ declare module "hot-shots" {
     path?: string;
     port?: number;
     prefix?: string;
-    protocol?: 'tcp' | 'udp' | 'uds';
+    protocol?: 'tcp' | 'udp' | 'uds' | 'stream';
     sampleRate?: number;
     socket?: dgram.Socket;
     suffix?: string;


### PR DESCRIPTION
Fixes #211.

Adds `stream` to protocol string union type.