### PR TITLE
Add missing decrement overload type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -81,6 +81,7 @@ declare module "hot-shots" {
     increment(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
 
     decrement(stat: string): void;
+    decrement(stat: string, tags?: Tags): void;
     decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
     decrement(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
     decrement(stat: string | string[], value: number, callback?: StatsCb): void;


### PR DESCRIPTION
It appears that the code already supports this overload, so I assume that it was just accidentally left out of the type definition. https://github.com/amc6/hot-shots/blob/master/lib/statsFunctions.js#L149