### PR TITLE
Document explicit prefix/suffix separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Parameters (specified as one object passed into hot-shots):
 * `host`:        The host to send stats to, if not set, the constructor tries to
   retrieve it from the `DD_AGENT_HOST` environment variable, `default: 'undefined'` which as per [UDP/datagram socket docs](https://nodejs.org/api/dgram.html#dgram_socket_send_msg_offset_length_port_address_callback) results in `127.0.0.1` or `::1` being used.
 * `port`:        The port to send stats to, if not set, the constructor tries to retrieve it from the `DD_DOGSTATSD_PORT` environment variable, `default: 8125`
-* `prefix`:      What to prefix each stat name with `default: ''`
-* `suffix`:      What to suffix each stat name with `default: ''`
+* `prefix`:      What to prefix each stat name with `default: ''`. Note prefix separator must be specified explicitly if desired (e.g. `my_prefix.`).
+* `suffix`:      What to suffix each stat name with `default: ''`. Note suffix separator must be specified explicitly if desired (e.g. `.my_suffix`).
 * `tagPrefix`:   Prefix tag list with character `default: '#'`. Note does not work with `telegraf` option.
 * `tagSeparator`: Separate tags with character `default: ','`. Note does not work with `telegraf` option.
 * `globalize`:   Expose this StatsD instance globally. `default: false`


### PR DESCRIPTION
This adds documentation for the `prefix` and `suffix` configs.

No separator (e.g. `.`) is added, so it should be included in the given string to separate the prefix/suffix from the rest of the metric name. See #215 for more context.

I tried implementing auto-separating prefixes and suffixes, but it turns out to be a little complex to keep the option for the old behaviour. This at least clarifies the existing behaviour, until such as time as it is decided to change it.