### PR TITLE
Fix tests

### DIFF
--- a/test/buffer.js
+++ b/test/buffer.js
@@ -65,7 +65,7 @@ describe('#buffer', () => {
       it('should not send batches larger then maxBufferSize', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {
-            maxBufferSize: 8,
+            maxBufferSize: 5,
           }), clientType);
           statsd.increment('a', 1);
           statsd.increment('b', 2);


### PR DESCRIPTION
Ran tests on a Mac M1 using node 14.

Got error: 
```
 Uncaught AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ 'a:1|c\nb:2|c\n'
- 'a:1|c\n'
          ^
      + expected - actual

       a:1|c
      -b:2|c
```

Looks like the number of characters for the first message is only 5 characters long so I suspect this is a broken test, however without more context this could actually be exposing a broken feature in which case this PR can be closed.