### PR TITLE
append standard Datadog tags from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ Parameters (specified as one object passed into hot-shots):
 * `mock`:        Create a mock StatsD instance, sending no stats to
   the server and allowing data to be read from mockBuffer.  Note that
   mockBuffer will keep growing, so only use for testing or clear out periodically. `default: false`
-* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. The *Datadog* `dd.internal.entity_id` tag is appended to `globalTags` from the `DD_ENTITY_ID` environment variable if the latter is set. `default: {}`
+* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. `default: {}`. The following *Datadog* tags are appended to `globalTags` from the corresponding environment variable if the latter is set:
+  * `dd.internal.entity_id` from `DD_ENTITY_ID` ([docs](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp))
+  * `env` from `DD_ENV` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
+  * `service` from `DD_SERVICE` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
+  * `version` from `DD_VERSION` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0`
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -12,6 +12,13 @@ const UDS_ERROR_CODES = constants.udsErrors();
 const TCP_DEFAULT_GRACEFUL_RESTART_LIMIT = 1000;
 const UDS_DEFAULT_GRACEFUL_RESTART_LIMIT = 1000;
 const CACHE_DNS_TTL_DEFAULT = 60000;
+// DD_ENV_GLOBAL_TAGS_MAPPING is a mapping of each "DD_" prefixed environment variable to a specific tag name.
+const DD_ENV_GLOBAL_TAGS_MAPPING = {
+  DD_ENTITY_ID: 'dd.internal.entity_id', // Client-side entity ID injection for container tagging.
+  DD_ENV: 'env', // The name of the env in which the service runs.
+  DD_SERVICE: 'service', // The name of the running service.
+  DD_VERSION: 'version', // The current version of the running service.
+};
 
 /**
  * The Client for StatsD.  The main entry-point for hot-shots.  Note adding new parameters
@@ -62,11 +69,11 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.mock        = options.mock;
   this.globalTags  = typeof options.globalTags === 'object' ?
       helpers.formatTags(options.globalTags, options.telegraf) : [];
-  if (process.env.DD_ENTITY_ID) {
-    this.globalTags = this.globalTags.filter((item) => {
-      return item.indexOf('dd.internal.entity_id:') !== 0;
-    });
-    this.globalTags.push('dd.internal.entity_id:'.concat(helpers.sanitizeTags(process.env.DD_ENTITY_ID)));
+  const availableDDEnvs = Object.keys(DD_ENV_GLOBAL_TAGS_MAPPING).filter(key => process.env[key]);
+  if (availableDDEnvs.length > 0) {
+    this.globalTags = this.globalTags.
+      filter((item) => !availableDDEnvs.some(env => item.startsWith(`${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:`))).
+      concat(availableDDEnvs.map(env => `${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:${helpers.sanitizeTags(process.env[env])}`));
   }
   this.telegraf = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;

--- a/test/init.js
+++ b/test/init.js
@@ -28,6 +28,9 @@ describe('#init', () => {
     delete process.env.DD_AGENT_HOST;
     delete process.env.DD_DOGSTATSD_PORT;
     delete process.env.DD_ENTITY_ID;
+    delete process.env.DD_ENV;
+    delete process.env.DD_SERVICE;
+    delete process.env.DD_VERSION;
   });
 
   it('should set the proper values when specified', () => {
@@ -131,20 +134,37 @@ describe('#init', () => {
     assert.deepStrictEqual(statsd.globalTags, ['gtag']);
   });
 
-  it('should get the dd.internal.entity_id tag from DD_ENTITY_ID env var', () => {
-    // set the DD_ENTITY_ID env var
+  it('should get global tags from DD_ prefixed env vars', () => {
+    // set DD_ prefixed env vars
     process.env.DD_ENTITY_ID = '04652bb7-19b7-11e9-9cc6-42010a9c016d';
+    process.env.DD_ENV = 'test';
+    process.env.DD_SERVICE = 'test-service';
+    process.env.DD_VERSION = '1.0.0';
 
     statsd = createHotShotsClient({}, clientType);
-    assert.deepStrictEqual(statsd.globalTags, ['dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
+    assert.deepStrictEqual(statsd.globalTags, [
+      'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d',
+      'env:test',
+      'service:test-service',
+      'version:1.0.0'
+    ]);
   });
 
-  it('should get the dd.internal.entity_id tag from DD_ENTITY_ID env var and append it to existing tags', () => {
-    // set the DD_ENTITY_ID env var
+  it('should get global tag from DD_ prefixed env vars and append them to existing tags', () => {
+    // set DD_ prefixed env vars
     process.env.DD_ENTITY_ID = '04652bb7-19b7-11e9-9cc6-42010a9c016d';
+    process.env.DD_ENV = 'test';
+    process.env.DD_SERVICE = 'test-service';
+    process.env.DD_VERSION = '1.0.0';
 
     statsd = createHotShotsClient({ globalTags: ['gtag'] }, clientType);
-    assert.deepStrictEqual(statsd.globalTags, ['gtag', 'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d']);
+    assert.deepStrictEqual(statsd.globalTags, [
+      'gtag',
+      'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d',
+      'env:test',
+      'service:test-service',
+      'version:1.0.0'
+    ]);
   });
 
   it('should not lookup a dns record if dnsCache is not specified', done => {


### PR DESCRIPTION
`env`, `service` and `version` are standard Datadog tags: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes

Since the `dd.internal.entity_id` tag has already been set from `DD_ENTITY_ID` env var, I think extending it to more standard tags makes sense.

Actually, the same thing has been done in the standard [Golang library](https://github.com/DataDog/datadog-go/blob/553de96e699a42be8b401607fbbbce81d4942790/statsd/statsd.go#L89-L98) and [Java library](https://github.com/DataDog/java-dogstatsd-client/pull/107) as well.