### PR TITLE
Add udpSocketOptions as a StatsD option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Parameters (specified as one object passed into hot-shots):
 * `udsGracefulErrorHandling`: Used only when the protocol is `uds`. Boolean indicating whether to handle socket errors gracefully. Defaults to true.
 * `udsGracefulRestartRateLimit`: Used only when the protocol is `uds`. Time (ms) between re-creating the socket. Defaults to `1000`.
 * `closingFlushInterval`: Before closing, StatsD will check for inflight messages. Time (ms) between each check. Defaults to `50`.
+* `udpSocketOptions`: Specify these options to control how StatsD will create a UDP (dgram) socket.
 
 ### StatsD methods
 All StatsD methods other than `event`, `close`, and `check` have the same API:

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -87,6 +87,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.udsGracefulRestartRateLimit = options.udsGracefulRestartRateLimit || UDS_DEFAULT_GRACEFUL_RESTART_LIMIT; // only recreate once per second
   this.isChild = options.isChild;
   this.closingFlushInterval = options.closingFlushInterval || 50;
+  this.udpSocketOptions = options.udpSocketOptions || { type: 'udp4' };
 
   // If we're mocking the client, create a buffer to record the outgoing calls.
   if (this.mock) {
@@ -623,5 +624,6 @@ function trySetNewSocket(client) {
     port: client.port,
     protocol: client.protocol,
     stream: client.stream,
+    udpSocketOptions: client.udpSocketOptions,
   });
 }

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -44,7 +44,7 @@ const createTcpTransport = args => {
 };
 
 const createUdpTransport = args => {
-  const socket = dgram.createSocket('udp4');
+  const socket = dgram.createSocket(args.udpSocketOptions);
   // do not block node from shutting down
   socket.unref();
 

--- a/test/udpSocketOptions.js
+++ b/test/udpSocketOptions.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const helpers = require('./helpers/helpers.js');
+const dns = require('dns');
+const dgram = require('dgram');
+
+const closeAll = helpers.closeAll;
+const createServer = helpers.createServer;
+const createHotShotsClient = helpers.createHotShotsClient;
+
+describe('#udpSocketOptions', () => {
+  const udpServerType = 'udp';
+  const originalDnsLookup = dns.lookup;
+  const originalDgramCreateSocket = dgram.createSocket;
+  let server;
+  let statsd;
+
+  afterEach(done => {
+    dns.lookup = originalDnsLookup;
+    dgram.createSocket = originalDgramCreateSocket;
+    closeAll(server, statsd, false, done);
+  });
+
+  it('should use custom DNS lookup function', done => {
+    const resolvedHostAddress = '127.0.0.1';
+    let dnsLookupCount = 0;
+    const customDnsLookup = (host, options, callback) => {
+      dnsLookupCount++;
+      callback(undefined, resolvedHostAddress);
+    };
+
+    server = createServer(udpServerType, opts => {
+      statsd = createHotShotsClient(Object.assign(opts, {
+        cacheDns: true,
+        udpSocketOptions: {
+          type: 'udp4',
+          lookup: customDnsLookup,
+        },
+      }), 'client');
+
+      statsd.send('test title', {}, (error) => {
+        assert.strictEqual(error, null);
+        setTimeout(() => {
+          assert.strictEqual(dnsLookupCount, 2);
+          done();
+        }, 1000);
+      });
+    });
+  });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,6 +30,7 @@ declare module "hot-shots" {
     udsGracefulErrorHandling?: boolean;
     udsGracefulRestartRateLimit?: number;
     closingFlushInterval?: number;
+    udpSocketOptions?: dgram.SocketOptions;
   }
 
   export interface ChildClientOptions {


### PR DESCRIPTION
This options allows the library user to control how the UDP socket is
created. If not specified, we maintain existing compatibility by
defaulting to a udp4 socket family with no other options.

Fixes #223