### PR TITLE
Only add DD_ prefixed tags if mapped tag value is not specified

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -69,7 +69,7 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.mock        = options.mock;
   this.globalTags  = typeof options.globalTags === 'object' ?
       helpers.formatTags(options.globalTags, options.telegraf) : [];
-  const availableDDEnvs = Object.keys(DD_ENV_GLOBAL_TAGS_MAPPING).filter(key => process.env[key]);
+  const availableDDEnvs = Object.keys(DD_ENV_GLOBAL_TAGS_MAPPING).filter(key => process.env[key] && !(DD_ENV_GLOBAL_TAGS_MAPPING[key] in (options.globalTags || {})));
   if (availableDDEnvs.length > 0) {
     this.globalTags = this.globalTags.
       filter((item) => !availableDDEnvs.some(env => item.startsWith(`${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:`))).

--- a/test/init.js
+++ b/test/init.js
@@ -167,6 +167,22 @@ describe('#init', () => {
     ]);
   });
 
+  it('should prefer global tags from options over DD_ prefixed env vars', () => {
+    // set DD_ prefixed env vars
+    process.env.DD_ENTITY_ID = '04652bb7-19b7-11e9-9cc6-42010a9c016d';
+    process.env.DD_ENV = 'test';
+    process.env.DD_SERVICE = 'test-service';
+    process.env.DD_VERSION = '1.0.0';
+
+    statsd = createHotShotsClient({ globalTags: { service: 'init-service' } }, clientType);
+    assert.deepStrictEqual(statsd.globalTags, [
+      'service:init-service',
+      'dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d',
+      'env:test',
+      'version:1.0.0'
+    ]);
+  });
+
   it('should not lookup a dns record if dnsCache is not specified', done => {
     const originalLookup = dns.lookup;
 


### PR DESCRIPTION
#224 is great, but I'm currently blocked on upgrading hot-shots because, for some of our services, we specify a value for `service` which is different than the value in the `DD_SERVICE` env var.

This PR modifies the logic so that user-provided globalTags take precedence over DD_ prefix tags. I believe this to be the least surprising behavior, but let me know what you think.