### PR TITLE
[WIP] Windows Named Pipe Support

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -26,7 +26,15 @@ const addEol = (buf) => {
 //   unref(): void;
 // }
 const createTcpTransport = args => {
-  const socket = net.connect(args.port, args.host);
+  const { port, host, path } = args;
+  let socket;
+  
+  if (!host && path) {
+    socket = net.connect(path);
+  } else {
+    socket = net.connect(port, host);
+  }
+
   socket.setKeepAlive(true);
   // do not block node from shutting down
   socket.unref();


### PR DESCRIPTION
`hot-shot` UDS support doesn't work on Windows because of reliance on `unix-dgram`

`dd-trace-js` is able to support named pipes through UDS as it just uses the `request` library which allows us to give `unix:${pipeName}` as input. [Source](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/exporters/common/request.js)

This PR aims to add support for named pipes via similar approach. The current implementation is broken, getting the error message at the end when I give the args below. I think the `net.connect(path)` is failing, if I try to give it a `connectionListener`, it isn't executed

```
protocol: "tcp",
path: "unix:\\.\pipe\dogstatsd-2145B4AF-BAF1-4EB3-9221-7A5C213E6A36"
```

```
Error: connect ENOENT unix:\\.\pipe\dogstatsd-2145B4AF-BAF1-4EB3-9221-7A5C213E6A36
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1300:16)
    at PipeConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)
```

Dogstatsd:

```
dogstatsd-named-pipes: start listening a new named pipe client on \\.\pipe\dogstatsd-2145B4AF-BAF1-4EB3-9221-7A5C213E6A36
```