### PR TITLE
Handle synchronous socket.send error in sendUsingDnsCache

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -63,7 +63,11 @@ const createUdpTransport = args => {
         }
         dnsResolutionData.resolvedAddress = address;
         dnsResolutionData.timestamp = now;
-        socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
+        try {
+          socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
+        } catch (socketError) {
+          callback(socketError);
+        }
       });
     } else {
       socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -70,7 +70,11 @@ const createUdpTransport = args => {
         }
       });
     } else {
-      socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
+      try {
+        socket.send(buf, 0, buf.length, args.port, dnsResolutionData.resolvedAddress, callback);
+      } catch (socketError) {
+        callback(socketError);
+      }
     }
   };
 
@@ -82,7 +86,11 @@ const createUdpTransport = args => {
       if (args.cacheDns) {
         sendUsingDnsCache(callback, buf);
       } else {
-        socket.send(buf, 0, buf.length, args.port, args.host, callback);
+        try {
+          socket.send(buf, 0, buf.length, args.port, args.host, callback);
+        } catch (socketError) {
+          callback(socketError);
+        }
       }
     },
     close: socket.close.bind(socket),


### PR DESCRIPTION
We are using UDP with DNS caching in production and noticed the occasional unhandled exception in our application when the datadog agent is unavailable. We tracked it down to the lookup branch of `sendUsingDnsCache` which calls `socket.send` within a callback. `socket.send` can throw a sync exception and not invoke `callback` as described here: https://nodejs.org/api/dgram.html#socketsendmsg-offset-length-port-address-callback.