### PR TITLE
Add option 'includeDataDogTags'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Parameters (specified as one object passed into hot-shots):
 * `mock`:        Create a mock StatsD instance, sending no stats to
   the server and allowing data to be read from mockBuffer.  Note that
   mockBuffer will keep growing, so only use for testing or clear out periodically. `default: false`
-* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. `default: {}`. The following *Datadog* tags are appended to `globalTags` from the corresponding environment variable if the latter is set:
+* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. `default: {}`. 
+* `includeDataDogTags`: Whether to include DataDog tags to the global tags. `default: true`. The following *Datadog* tags are appended to `globalTags` from the corresponding environment variable if the latter is set:
   * `dd.internal.entity_id` from `DD_ENTITY_ID` ([docs](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp))
   * `env` from `DD_ENV` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
   * `service` from `DD_SERVICE` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -69,11 +69,14 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
   this.mock        = options.mock;
   this.globalTags  = typeof options.globalTags === 'object' ?
       helpers.formatTags(options.globalTags, options.telegraf) : [];
-  const availableDDEnvs = Object.keys(DD_ENV_GLOBAL_TAGS_MAPPING).filter(key => process.env[key]);
-  if (availableDDEnvs.length > 0) {
-    this.globalTags = this.globalTags.
-      filter((item) => !availableDDEnvs.some(env => item.startsWith(`${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:`))).
-      concat(availableDDEnvs.map(env => `${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:${helpers.sanitizeTags(process.env[env])}`));
+  this.includeDataDogTags = options.includeDataDogTags !== false;
+  if (this.includeDataDogTags) {
+    const availableDDEnvs = Object.keys(DD_ENV_GLOBAL_TAGS_MAPPING).filter(key => process.env[key]);
+    if (availableDDEnvs.length > 0) {
+      this.globalTags = this.globalTags.
+        filter((item) => !availableDDEnvs.some(env => item.startsWith(`${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:`))).
+        concat(availableDDEnvs.map(env => `${DD_ENV_GLOBAL_TAGS_MAPPING[env]}:${helpers.sanitizeTags(process.env[env])}`));
+    }
   }
   this.telegraf = options.telegraf || false;
   this.maxBufferSize = options.maxBufferSize || 0;
@@ -506,6 +509,7 @@ const ChildClient = function (parent, options) {
     // Append child's tags to parent's tags
     globalTags  : typeof options.globalTags === 'object' ?
         helpers.overrideTags(parent.globalTags, options.globalTags, parent.telegraf) : parent.globalTags,
+    includeDataDogTags: parent.includeDataDogTags,
     maxBufferSize : parent.maxBufferSize,
     bufferFlushInterval: parent.bufferFlushInterval,
     telegraf    : parent.telegraf,

--- a/test/globalTags.js
+++ b/test/globalTags.js
@@ -66,6 +66,29 @@ describe('#globalTags', () => {
         });
       });
 
+      it('should not add global tags from DD_ prefixed env vars if opted out', done => {
+        // set DD_ prefixed env vars
+        process.env.DD_ENTITY_ID = '04652bb7-19b7-11e9-9cc6-42010a9c016d';
+        process.env.DD_ENV = 'test';
+        process.env.DD_SERVICE = 'test-service';
+        process.env.DD_VERSION = '1.0.0';
+
+        server = createServer(serverType, opts => {
+          statsd = createHotShotsClient(Object.assign(opts, {
+            global_tags: ['gtag-dd-optout'],
+            includeDataDogTags: false,
+          }), clientType);
+          statsd.increment('test-gtag-dd-optout');
+        });
+        server.on('metrics', metrics => {
+          assert.strictEqual(
+            metrics,
+            `test-gtag-dd-optout:1|c|#gtag-dd-optout${metricEnd}`
+          );
+          done();
+        });
+      });
+
       it('should combine global tags and metric tags', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {


### PR DESCRIPTION
Adds option `includeDataDogTags` that allows creating a client that ignores the `DD_*` env vars.

Solves:
- https://github.com/brightcove/hot-shots/issues/203
- https://github.com/brightcove/hot-shots/issues/274
