### PR TITLE
Add 'includeDataDogTags' property to 'ClientOptions' type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -10,6 +10,7 @@ declare module "hot-shots" {
     cacheDnsTtl?: number;
     errorHandler?: (err: Error) => void;
     globalTags?: Tags;
+    includeDataDogTags?: boolean;
     globalize?: boolean;
     host?: string;
     isChild?: boolean;


### PR DESCRIPTION
I didn't notice the `ClientOptions` type on #275, so property `includeDataDogTags` is not known for TypeScript projects.

This PR is the attempt to fix it, sorry.