### PR TITLE
Buffering updates (especially for UDS) and mock client fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 coverage
 test/helpers/test.sock
 .vscode/
+.claude/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,10 @@ CHANGELOG
 ## 11.0.0 (2024-10-19)
 
 * @bdeitte Enable buffering by default (as 8192) for UDS connections
-* @bdeitte Ensure client.close() does not throws errors when mock: true is set
-* @bdeitte Add CLAUDE.md for easlier Claude usage
 * @bdeitte Stop adding extra newline in buffering cases where it's not needed
 * @bdeitte Flush buffering earlier when possible
+* @bdeitte Add CLAUDE.md for easlier Claude usage
+* @bdeitte Ensure client.close() does not throws errors when mock: true is set
 
 ## 10.2.1 (2024-10-19)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+## 11.0.0 (2024-10-19)
+
+* @bdeitte Enable buffering by default (as 8192) for UDS connections
+* @bdeitte Ensure client.close() does not throws errors when mock: true is set
+* @bdeitte Add CLAUDE.md for easlier Claude usage
+* @bdeitte Stop adding extra newline in buffering cases where it's not needed
+* @bdeitte Flush buffering earlier when possible
+
 ## 10.2.1 (2024-10-19)
 
 * @thiago-negri Add 'includeDataDogTags' property to 'ClientOptions' type

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+hot-shots is a Node.js client library for StatsD, DogStatsD (Datadog), and Telegraf (InfluxDB) metrics collection. It provides a comprehensive API for sending various types of metrics (counters, gauges, histograms, etc.) over UDP, TCP, UDS (Unix Domain Sockets), or raw streams.
+
+## Key Architecture
+
+### Core Components
+- **lib/statsd.js**: Main Client class and constructor logic
+- **lib/transport.js**: Protocol implementations (UDP, TCP, UDS, stream)
+- **lib/statsFunctions.js**: Core metric methods (timing, increment, gauge, etc.)
+- **lib/helpers.js**: Tag formatting, sanitization, and utility functions
+- **lib/constants.js**: Protocol constants and error codes
+- **index.js**: Main entry point (exports lib/statsd.js)
+- **types.d.ts**: TypeScript type definitions
+
+### Protocol Support
+The library supports multiple transport protocols:
+- **UDP**: Default protocol using dgram sockets
+- **TCP**: Persistent connection with graceful error handling
+- **UDS**: Unix Domain Sockets (requires unix-dgram optional dependency)
+- **Stream**: Raw stream protocol for custom transports
+
+### Client Architecture
+- Main Client class handles initialization and configuration
+- Transport layer abstracts protocol differences
+- Stats functions are mixed into Client prototype
+- Child clients inherit parent configuration with overrides
+
+## Development Commands
+
+### Testing
+```bash
+npm test                    # Run all tests with linting
+npm run lint               # Run ESLint on lib and test files
+npm run coverage          # Run tests with coverage report
+```
+
+### Linting
+The project uses ESLint 5.x with pretest hooks. All code must pass linting before tests run.
+
+### Running Single Tests
+```bash
+npx mocha test/specific-test.js --timeout 5000
+```
+
+## Key Development Patterns
+
+### Error Handling
+- Uses errorHandler callback pattern for transport errors
+- Graceful error handling for TCP/UDS with restart rate limiting
+- Different error handling strategies per protocol
+
+### Metric Buffering
+- Optional buffering with maxBufferSize and bufferFlushInterval
+- Automatic flushing on buffer size or time intervals
+- Buffer management in transport layer
+
+### Tag System
+- Supports both object and array tag formats
+- Tag sanitization prevents protocol-breaking characters
+- Global tags merged with per-metric tags
+- Special handling for Telegraf vs StatsD/DogStatsD tag formats
+
+### Child Clients
+- Inherit parent configuration
+- Can override prefix, suffix, globalTags
+- Nested child clients supported
+
+## Protocol-Specific Features
+
+### DataDog (DogStatsD)
+- Events and service checks
+- Distribution metrics
+- Automatic DD_* environment variable tag injection
+- Unix Domain Socket support
+
+### Telegraf
+- Different tag separator format
+- Histogram support
+- Modified tag sanitization rules
+
+## Testing Approach
+
+The project uses Mocha with 5-second timeouts. Tests are organized by feature:
+- Protocol-specific tests (UDP, TCP, UDS)
+- Metric type tests (counters, gauges, histograms)
+- Error handling and edge cases
+- Child client functionality
+- Buffering and performance tests
+
+## Dependencies
+
+- **Production**: No runtime dependencies (unix-dgram is optional)
+- **Development**: eslint, mocha, nyc for testing and linting
+- **Optional**: unix-dgram for Unix Domain Socket support
+
+## Important Notes
+
+- TypeScript definitions in types.d.ts must be updated for API changes
+- Constructor parameter expansion is deprecated - use options object
+- Mock mode available for testing (prevents actual metric sending)
+- DNS caching available for UDP protocol performance

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Parameters (specified as one object passed into hot-shots):
 * `mock`:        Create a mock StatsD instance, sending no stats to
   the server and allowing data to be read from mockBuffer.  Note that
   mockBuffer will keep growing, so only use for testing or clear out periodically. `default: false`
-* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. `default: {}`. 
+* `globalTags`:  Tags that will be added to every metric. Can be either an object or list of tags. `default: {}`.
 * `includeDataDogTags`: Whether to include DataDog tags to the global tags. `default: true`. The following *Datadog* tags are appended to `globalTags` from the corresponding environment variable if the latter is set:
   * `dd.internal.entity_id` from `DD_ENTITY_ID` ([docs](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp))
   * `env` from `DD_ENV` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
   * `service` from `DD_SERVICE` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
   * `version` from `DD_VERSION` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
-* `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0`
+* `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0` for udp and tcp.  `default: 8192` for uds.
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`
 * `sampleRate`:    Sends only a sample of data to StatsD for all StatsD methods.  Can be overridden at the method level. `default: 1`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -28,6 +28,9 @@ function formatTags(tags, telegraf) {
  * array. parent and child are not mutated.
  */
 function overrideTags (parent, child, telegraf) {
+  if (! child) {
+    return false;
+  }
   const childCopy = {};
   const toAppend = [];
   formatTags(child, telegraf).forEach(tag => {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -340,7 +340,7 @@ Client.prototype.sendMessage = function (message, callback) {
   // don't waste the time if we aren't sending anything
   if (message === '' || this.mock) {
     if (callback) {
-      callback(null);
+      callback();
     }
     return;
   }

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -79,7 +79,13 @@ const Client = function (host, port, prefix, suffix, globalize, cacheDns, mock,
     }
   }
   this.telegraf = options.telegraf || false;
-  this.maxBufferSize = options.maxBufferSize || 0;
+  if (options.maxBufferSize !== undefined) {
+    this.maxBufferSize = options.maxBufferSize;
+  } else if (this.protocol === PROTOCOL.UDS) {
+     this.maxBufferSize = 8192; // 8KiB as recommended by Datadog for UDS
+  } else {
+    this.maxBufferSize = 0;
+  }
   this.sampleRate = options.sampleRate || 1;
   this.bufferFlushInterval = options.bufferFlushInterval || 1000;
   this.bufferHolder = options.isChild ? options.bufferHolder : { buffer: '' };
@@ -299,14 +305,17 @@ Client.prototype._send = function (message, callback) {
  * @param message {String} The constructed message without tags
  */
 Client.prototype.enqueue = function (message, callback) {
-  message += '\n';
-
   if (this.bufferHolder.buffer.length + message.length > this.maxBufferSize) {
     this.flushQueue(callback);
     this.bufferHolder.buffer += message;
   }
   else {
-    this.bufferHolder.buffer += message;
+    if (this.bufferHolder.buffer === '') {
+      this.bufferHolder.buffer += message;
+    }
+    else {
+      this.bufferHolder.buffer += '\n' + message;
+    }
     if (callback) {
       callback(null);
     }
@@ -399,9 +408,17 @@ Client.prototype.onBufferFlushInterval = function () {
  * Close the underlying socket and stop listening for data on it.
  */
 Client.prototype.close = function (callback) {
-  // stop trying to flush the queue on an interval
+    // stop trying to flush the queue on an interval
   if (this.intervalHandle) {
     clearInterval(this.intervalHandle);
+  }
+
+// For mock clients, just call the callback and return early
+  if (this.mock) {
+    if (callback) {
+      return callback();
+    }
+    return;
   }
 
   // flush the queue one last time, if needed

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -338,7 +338,7 @@ Client.prototype.flushQueue = function (callback) {
  */
 Client.prototype.sendMessage = function (message, callback) {
   // don't waste the time if we aren't sending anything
-  if (message === '') {
+  if (message === '' || this.mock) {
     if (callback) {
       callback(null);
     }
@@ -411,14 +411,6 @@ Client.prototype.close = function (callback) {
     // stop trying to flush the queue on an interval
   if (this.intervalHandle) {
     clearInterval(this.intervalHandle);
-  }
-
-// For mock clients, just call the callback and return early
-  if (this.mock) {
-    if (callback) {
-      return callback();
-    }
-    return;
   }
 
   // flush the queue one last time, if needed

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -305,20 +305,18 @@ Client.prototype._send = function (message, callback) {
  * @param message {String} The constructed message without tags
  */
 Client.prototype.enqueue = function (message, callback) {
-  if (this.bufferHolder.buffer.length + message.length > this.maxBufferSize) {
-    this.flushQueue(callback);
+  if (this.bufferHolder.buffer === '') {
     this.bufferHolder.buffer += message;
   }
   else {
-    if (this.bufferHolder.buffer === '') {
-      this.bufferHolder.buffer += message;
-    }
-    else {
-      this.bufferHolder.buffer += '\n' + message;
-    }
-    if (callback) {
+    this.bufferHolder.buffer += '\n' + message;
+  }
+
+  if (this.bufferHolder.buffer.length > this.maxBufferSize) {
+    this.flushQueue(callback);
+  }
+  else if (callback) {
       callback(null);
-    }
   }
 };
 
@@ -326,8 +324,10 @@ Client.prototype.enqueue = function (message, callback) {
  * Flush the buffer, sending on the messages
  */
 Client.prototype.flushQueue = function (callback) {
-  this.sendMessage(this.bufferHolder.buffer, callback);
+  const currentMessage = this.bufferHolder.buffer;
   this.bufferHolder.buffer = '';
+  this.sendMessage(currentMessage, callback);
+
 };
 
 /**
@@ -408,7 +408,7 @@ Client.prototype.onBufferFlushInterval = function () {
  * Close the underlying socket and stop listening for data on it.
  */
 Client.prototype.close = function (callback) {
-    // stop trying to flush the queue on an interval
+  // stop trying to flush the queue on an interval
   if (this.intervalHandle) {
     clearInterval(this.intervalHandle);
   }

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -6,7 +6,7 @@ const testTypes = helpers.testTypes;
 const createServer = helpers.createServer;
 const createHotShotsClient = helpers.createHotShotsClient;
 
-describe('#buffer', () => {
+describe.only('#buffer', () => {
   let server;
   let statsd;
 
@@ -65,7 +65,7 @@ describe('#buffer', () => {
       it('should not send batches larger then maxBufferSize', done => {
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {
-            maxBufferSize: 8,
+            maxBufferSize: 2,
           }), clientType);
           statsd.increment('a', 1);
           statsd.increment('b', 2);
@@ -95,33 +95,4 @@ describe('#buffer', () => {
       });
     });
   });
-
-  // Test UDS specific default buffering behavior
-  if (require('os').platform() !== 'win32') {
-    describe('UDS default buffering', () => {
-      it('should enable 8KiB buffering by default for UDS protocol', done => {
-        server = createServer('uds', opts => {
-          // Don't set maxBufferSize to test the default
-          statsd = createHotShotsClient(opts, 'client');
-
-          // Verify the default buffer size is 8192 for UDS
-          assert.strictEqual(statsd.maxBufferSize, 8192);
-          done();
-        });
-      });
-
-      it('should allow override of default UDS buffering', done => {
-        server = createServer('uds', opts => {
-          // Explicitly set maxBufferSize to 0 to override the default
-          statsd = createHotShotsClient(Object.assign(opts, {
-            maxBufferSize: 0,
-          }), 'client');
-
-          // Verify the override works
-          assert.strictEqual(statsd.maxBufferSize, 0);
-          done();
-        });
-      });
-    });
-  }
 });

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -6,7 +6,7 @@ const testTypes = helpers.testTypes;
 const createServer = helpers.createServer;
 const createHotShotsClient = helpers.createHotShotsClient;
 
-describe.only('#buffer', () => {
+describe('#buffer', () => {
   let server;
   let statsd;
 
@@ -63,14 +63,21 @@ describe.only('#buffer', () => {
       });
 
       it('should not send batches larger then maxBufferSize', done => {
+        let calledMetrics = false;
         server = createServer(serverType, opts => {
           statsd = createHotShotsClient(Object.assign(opts, {
             maxBufferSize: 2,
           }), clientType);
           statsd.increment('a', 1);
-          statsd.increment('b', 2);
+          setTimeout(() => {
+            if (! calledMetrics) {
+              // give a small delay to ensure the buffer is flushed
+              statsd.increment('b', 2);
+            }
+          }, 50);
         });
         server.once('metrics', metrics => {
+          calledMetrics = true;
           assert.strictEqual(metrics, `a:1|c${metricsEnd}`);
           done();
         });

--- a/test/childClient.js
+++ b/test/childClient.js
@@ -18,7 +18,7 @@ describe('#childClient', () => {
     statsd = null;
   });
 
-  testProtocolTypes().forEach(([description, serverType, clientType]) => {
+  testProtocolTypes().forEach(([description, serverType, clientType, metricsEnd]) => {
 
     describe(description, () => {
       it('init should set the proper values when specified', () => {
@@ -55,7 +55,7 @@ describe('#childClient', () => {
           statsd.increment('b', 2);
       });
       server.on('metrics', metrics => {
-        assert.strictEqual(metrics, 'preff.a.suff:1|c|#awesomeness:over9000\npreff.b.suff:2|c|#awesomeness:over9000\n');
+        assert.strictEqual(metrics, `preff.a.suff:1|c|#awesomeness:over9000\npreff.b.suff:2|c|#awesomeness:over9000${metricsEnd}`);
         done();
       });
     });
@@ -77,7 +77,7 @@ describe('#childClient', () => {
       });
       server.on('metrics', metrics => {
         assert.strictEqual(metrics, 'preff.p.a.s.suff:1|c|#xyz,awesomeness:' +
-          'over9000\npreff.p.b.s.suff:2|c|#xyz,awesomeness:over9000\n'
+          `over9000\npreff.p.b.s.suff:2|c|#xyz,awesomeness:over9000${metricsEnd}`
         );
         done();
       });

--- a/test/close.js
+++ b/test/close.js
@@ -62,7 +62,7 @@ describe('#close', () => {
         server.on('metrics', metrics => {
           // this uses '\n' instead of metricsEnd because that's how things are set up when
           // maxBufferSize is in use
-          assert.strictEqual(metrics, 'test:42|s\n');
+          assert.strictEqual(metrics, `test:42|s${metricsEnd}`);
           metricSeen = true;
         });
       });
@@ -87,7 +87,7 @@ describe('#close', () => {
         server.on('metrics', metrics => {
           // this uses '\n' instead of metricsEnd because that's how things are set up when
           // maxBufferSize is in use
-          assert.strictEqual(metrics, 'test:42|s\n');
+          assert.strictEqual(metrics, `test:42|s${metricsEnd}`);
           metricSeen = true;
         });
       });

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -402,7 +402,6 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
-                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -432,7 +431,6 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
-                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -463,7 +461,6 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
-                maxBufferSize: 0, // disable to test error handling more easily
                 udsGracefulRestartRateLimit: limit,
                 errorHandler(error) {
                   assert.ok(error);
@@ -500,7 +497,6 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
-                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -534,7 +530,6 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
-                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -572,7 +567,6 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
-                maxBufferSize: 0, // disable to test error handling more easily
                 udsGracefulErrorHandling: false,
                 errorHandler(error) {
                   assert.ok(error);

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -402,6 +402,7 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
+                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -431,6 +432,7 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
+                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -461,6 +463,7 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
+                maxBufferSize: 0, // disable to test error handling more easily
                 udsGracefulRestartRateLimit: limit,
                 errorHandler(error) {
                   assert.ok(error);
@@ -497,6 +500,7 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
+                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -530,6 +534,7 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
+                maxBufferSize: 0, // disable to test error handling more easily
                 errorHandler(error) {
                   assert.ok(error);
                   assert.strictEqual(error.code, code);
@@ -567,6 +572,7 @@ describe('#errorHandling', () => {
             server = createServer('uds_broken', opts => {
               const client = statsd = createHotShotsClient(Object.assign(opts, {
                 protocol: 'uds',
+                maxBufferSize: 0, // disable to test error handling more easily
                 udsGracefulErrorHandling: false,
                 errorHandler(error) {
                   assert.ok(error);

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -80,7 +80,7 @@ function testTypes() {
     [`${TCP} ${CLIENT}`, TCP, CLIENT, TCP_METRIC_END],
     [`${TCP} ${CHILD_CLIENT}`, TCP, CHILD_CLIENT, TCP_METRIC_END]];
 
-  // Not everywhere can run UDS, and we don't want to fail the tests in those places
+   // Not everywhere can run UDS, and we don't want to fail the tests in those places
   if (os.platform() !== 'win32') {
     testTypesArr.push([`${UDS} ${CLIENT}`, UDS, CLIENT, UDS_METRIC_END]);
     testTypesArr.push([`${UDS} ${CHILD_CLIENT}`, UDS, CLIENT, UDS_METRIC_END]);
@@ -225,7 +225,7 @@ function createServer(serverType, callback) {
  * @param {*} clientType
  */
 function createHotShotsClient(args, clientType) {
-  if (clientType === UDS && ! args.maxBufferSize) {
+  if (args.protocol === UDS && ! args.maxBufferSize) {
     args.maxBufferSize = 1; // use a buffer like normal but shrink to get messages early
   }
    /* eslint-disable require-jsdoc */

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -225,6 +225,9 @@ function createServer(serverType, callback) {
  * @param {*} clientType
  */
 function createHotShotsClient(args, clientType) {
+  if (clientType === UDS && ! args.maxBufferSize) {
+    args.maxBufferSize = 1; // use a buffer like normal but shrink to get messages early
+  }
    /* eslint-disable require-jsdoc */
   function construct(ctor, constructArgs) {
     function F() {

--- a/test/statsFunctions.js
+++ b/test/statsFunctions.js
@@ -92,7 +92,7 @@ describe('#statsFunctions', () => {
               });
             });
             server.on('metrics', metrics => {
-              assert.strictEqual(metrics, `a:${statFunction.sign}42|${statFunction.unit}\nb:${statFunction.sign}42|${statFunction.unit}\n`);
+              assert.strictEqual(metrics, `a:${statFunction.sign}42|${statFunction.unit}\nb:${statFunction.sign}42|${statFunction.unit}${metricsEnd}`);
               done();
             });
           });
@@ -236,9 +236,9 @@ describe('#statsFunctions', () => {
             });
           });
           server.on('metrics', metrics => {
-            assert.strictEqual(metrics, 'a:42|c\nb:42|c\n');
+            assert.strictEqual(metrics, `a:42|c\nb:42|c${metricsEnd}`);
             done();
-          });
+        });
         });
       });
 
@@ -320,9 +320,9 @@ describe('#statsFunctions', () => {
             });
           });
           server.on('metrics', metrics => {
-            assert.strictEqual(metrics, 'a:-42|c\nb:-42|c\n');
+            assert.strictEqual(metrics, `a:-42|c\nb:-42|c${metricsEnd}`);
             done();
-          });
+        });
         });
       });
     });


### PR DESCRIPTION
As noted in the changelog:

* @bdeitte Enable buffering by default (as 8192) for UDS connections
* @bdeitte Stop adding extra newline in buffering cases where it's not needed
* @bdeitte Flush buffering earlier when possible
* @bdeitte Add CLAUDE.md for easlier Claude usage
* @bdeitte Ensure client.close() does not throws errors when mock: true is set

The buffering changes were larger than I expected, so this will be a major bump.  Fixes https://github.com/brightcove/hot-shots/issues/273 and https://github.com/brightcove/hot-shots/issues/244