### PR TITLE
Replace unix-dgram to unix_dgram_rs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ hot-shots is a Node.js client library for StatsD, DogStatsD (Datadog), and Teleg
 The library supports multiple transport protocols:
 - **UDP**: Default protocol using dgram sockets
 - **TCP**: Persistent connection with graceful error handling
-- **UDS**: Unix Domain Sockets (requires unix-dgram optional dependency)
+- **UDS**: Unix Domain Sockets (requires unix-dgram-rs dependency)
 - **Stream**: Raw stream protocol for custom transports
 
 ### Client Architecture

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -4,12 +4,10 @@ const net = require('net');
 const dns = require('dns');
 const os = require('os');
 const util = require('util');
+const unixDgram = require('unix_dgram_rs');
 const { PROTOCOL } = require('./constants');
 
 const debug = util.debuglog('hot-shots');
-
-// Imported below, only if needed
-let unixDgram;
 
 const UDS_PATH_DEFAULT = '/var/run/datadog/dsd.socket';
 
@@ -231,21 +229,10 @@ const createUdpTransport = args => {
 /**
  * Creates a Unix Domain Socket (UDS) transport for local IPC metric delivery.
  * Implements automatic retry logic with exponential backoff for EAGAIN and congestion errors.
- * Requires the optional unix-dgram dependency to be installed.
  * @param {Object} args - Configuration options including path and udsRetryOptions
  * @returns {Transport} A transport object implementing the Transport interface
  */
 const createUdsTransport = args => {
-  try {
-    // This will not always be available, as noted in the error message below
-    unixDgram = require('unix-dgram'); // eslint-disable-line global-require
-  } catch (err) {
-    throw new Error(
-      'The library `unix_dgram`, needed for the uds protocol to work, is not installed. ' +
-      'You need to pick another protocol to use hot-shots. ' +
-      'See the hot-shots README for additional details.'
-    );
-  }
   // Only retry-related options live here now
   const udsOpts = args.udsRetryOptions || {};
   const udsPath = args.path ? args.path : UDS_PATH_DEFAULT;
@@ -284,8 +271,8 @@ const createUdsTransport = args => {
   };
 
   /**
-   * Checks if an error is a congestion error from unix-dgram.
-   * unix-dgram returns an internal 'congestion' error (err === 1) via callback.
+   * Checks if an error is a congestion error from unix_dgram_rs.
+   * unix_dgram_rs returns an internal 'congestion' error (err === 1) via callback.
    * @param {Error} err - The error to check
    * @returns {boolean} True if the error is a congestion error
    */
@@ -351,7 +338,7 @@ const createUdsTransport = args => {
       socket.emit('close');
     },
     unref: () => {
-      throw new Error('unix-dgram does not implement unref for sockets');
+      throw new Error('unix_dgram_rs does not implement unref for sockets');
     }
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "hot-shots",
       "version": "14.0.0",
       "license": "MIT",
+      "dependencies": {
+        "unix_dgram_rs": "^0.1.0-alpha.1"
+      },
       "devDependencies": {
         "eslint": "8.x",
         "mocha": "10.x",
@@ -16,9 +19,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      },
-      "optionalDependencies": {
-        "unix-dgram": "2.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -62,6 +62,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -595,6 +596,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -728,15 +730,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -784,6 +777,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -1085,6 +1079,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1273,12 +1268,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -2102,12 +2091,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3033,18 +3016,117 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/unix-dgram": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.7.tgz",
-      "integrity": "sha512-pWaQorcdxEUBFIKjCqqIlQaOoNVmchyoaNAJ/1LwyyfK2XSxcBhgJNiSE8ZRhR0xkNGyk4xInt1G03QPoKXY5A==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.20.0"
-      },
+    "node_modules/unix_dgram_rs": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs/-/unix_dgram_rs-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-FLJbrIWY4pJoDp6fhaKnD9Wy/NnLmIV19a6w1pW5y6kxBI1mOqMKGMdqfd7ljConnVcT4bf6vc/taun8mKceEg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.48"
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "unix_dgram_rs-darwin-arm64": "0.1.0-alpha.1",
+        "unix_dgram_rs-darwin-x64": "0.1.0-alpha.1",
+        "unix_dgram_rs-linux-arm64-gnu": "0.1.0-alpha.1",
+        "unix_dgram_rs-linux-x64-gnu": "0.1.0-alpha.1",
+        "unix_dgram_rs-win32-arm64-msvc": "0.1.0-alpha.1",
+        "unix_dgram_rs-win32-x64-msvc": "0.1.0-alpha.1"
+      }
+    },
+    "node_modules/unix_dgram_rs-darwin-arm64": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-darwin-arm64/-/unix_dgram_rs-darwin-arm64-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-KsHh8pNu307vZQki5IbcDJZTHoZeWPpv0NOgAB4z03cwHKpbkrjnJtZXi598uHuBOtYDnQXfCAHnQNPnz1iuwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/unix_dgram_rs-darwin-x64": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-darwin-x64/-/unix_dgram_rs-darwin-x64-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-2Jq4+3uAnlqGarF8DY/gX+cKgrxm98jJ3g6whk3eALv/uM91r3IeinfCLfJrkkA4Qf3/Yef3dLXyjISZTraIDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/unix_dgram_rs-linux-arm64-gnu": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-linux-arm64-gnu/-/unix_dgram_rs-linux-arm64-gnu-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-x8igm6Yl8k+RVxW58iHTBbNbBq8/8xdS3K16JgtY5XhU9di9Mk1qOHwm6dBtd62UPMPZJi6POk59PVVfHlfqrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/unix_dgram_rs-linux-x64-gnu": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-linux-x64-gnu/-/unix_dgram_rs-linux-x64-gnu-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-jhiugi/mUf+9NN52qcUFUeL26eS/NgEhRRKrlOonoN9LPg3ThSNu+5834xb9QyvDyzkc48/txSuLPupMVdJS/w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/unix_dgram_rs-win32-arm64-msvc": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-win32-arm64-msvc/-/unix_dgram_rs-win32-arm64-msvc-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-15KeOXzN3jPhGA6/uGZHd6DiT7ZeaueTCgOvrk7CnFSMMAaMynJoL4Nz+U9slgpkgWkb6LII8kcmEbZehI7New==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/unix_dgram_rs-win32-x64-msvc": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-win32-x64-msvc/-/unix_dgram_rs-win32-x64-msvc-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-Q+SMkj+NRGaMo4iVChMTNJKLlBaDoHht7MKqQ0lzbURYW7ZMM5ZoE6rW/zxxCC3VnVcWjPo6B5pT91T32Nzx0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3293,6 +3375,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3699,7 +3782,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -3794,15 +3878,6 @@
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3833,6 +3908,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
       "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -4048,6 +4124,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4187,12 +4264,6 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
     },
     "fill-range": {
       "version": "7.1.1",
@@ -4795,12 +4866,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5475,15 +5540,54 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "unix-dgram": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.7.tgz",
-      "integrity": "sha512-pWaQorcdxEUBFIKjCqqIlQaOoNVmchyoaNAJ/1LwyyfK2XSxcBhgJNiSE8ZRhR0xkNGyk4xInt1G03QPoKXY5A==",
-      "optional": true,
+    "unix_dgram_rs": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs/-/unix_dgram_rs-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-FLJbrIWY4pJoDp6fhaKnD9Wy/NnLmIV19a6w1pW5y6kxBI1mOqMKGMdqfd7ljConnVcT4bf6vc/taun8mKceEg==",
       "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.20.0"
+        "unix_dgram_rs-darwin-arm64": "0.1.0-alpha.1",
+        "unix_dgram_rs-darwin-x64": "0.1.0-alpha.1",
+        "unix_dgram_rs-linux-arm64-gnu": "0.1.0-alpha.1",
+        "unix_dgram_rs-linux-x64-gnu": "0.1.0-alpha.1",
+        "unix_dgram_rs-win32-arm64-msvc": "0.1.0-alpha.1",
+        "unix_dgram_rs-win32-x64-msvc": "0.1.0-alpha.1"
       }
+    },
+    "unix_dgram_rs-darwin-arm64": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-darwin-arm64/-/unix_dgram_rs-darwin-arm64-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-KsHh8pNu307vZQki5IbcDJZTHoZeWPpv0NOgAB4z03cwHKpbkrjnJtZXi598uHuBOtYDnQXfCAHnQNPnz1iuwQ==",
+      "optional": true
+    },
+    "unix_dgram_rs-darwin-x64": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-darwin-x64/-/unix_dgram_rs-darwin-x64-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-2Jq4+3uAnlqGarF8DY/gX+cKgrxm98jJ3g6whk3eALv/uM91r3IeinfCLfJrkkA4Qf3/Yef3dLXyjISZTraIDw==",
+      "optional": true
+    },
+    "unix_dgram_rs-linux-arm64-gnu": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-linux-arm64-gnu/-/unix_dgram_rs-linux-arm64-gnu-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-x8igm6Yl8k+RVxW58iHTBbNbBq8/8xdS3K16JgtY5XhU9di9Mk1qOHwm6dBtd62UPMPZJi6POk59PVVfHlfqrg==",
+      "optional": true
+    },
+    "unix_dgram_rs-linux-x64-gnu": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-linux-x64-gnu/-/unix_dgram_rs-linux-x64-gnu-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-jhiugi/mUf+9NN52qcUFUeL26eS/NgEhRRKrlOonoN9LPg3ThSNu+5834xb9QyvDyzkc48/txSuLPupMVdJS/w==",
+      "optional": true
+    },
+    "unix_dgram_rs-win32-arm64-msvc": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-win32-arm64-msvc/-/unix_dgram_rs-win32-arm64-msvc-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-15KeOXzN3jPhGA6/uGZHd6DiT7ZeaueTCgOvrk7CnFSMMAaMynJoL4Nz+U9slgpkgWkb6LII8kcmEbZehI7New==",
+      "optional": true
+    },
+    "unix_dgram_rs-win32-x64-msvc": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/unix_dgram_rs-win32-x64-msvc/-/unix_dgram_rs-win32-x64-msvc-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-Q+SMkj+NRGaMo4iVChMTNJKLlBaDoHht7MKqQ0lzbURYW7ZMM5ZoE6rW/zxxCC3VnVcWjPo6B5pT91T32Nzx0g==",
+      "optional": true
     },
     "update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "lint": "eslint \"./lib/**/*.js\" \"./test/**/*.js\"",
     "pretest": "npm run lint"
   },
-  "optionalDependencies": {
-    "unix-dgram": "2.x"
-  },
   "devDependencies": {
     "eslint": "8.x",
     "mocha": "10.x",
@@ -45,5 +42,7 @@
     "sinon": "19.x"
   },
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "unix_dgram_rs": "^0.1.0-alpha.1"
+  }
 }

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -619,12 +619,7 @@ describe('#errorHandling', () => {
              */
             function createUdsTestServer(socketPath, messageHandler) {
               const fs = require('fs'); // eslint-disable-line global-require
-              let unixDgram;
-              try {
-                unixDgram = require('unix-dgram'); // eslint-disable-line global-require
-              } catch (e) {
-                return null;
-              }
+              const unixDgram = require('unix_dgram_rs'); // eslint-disable-line global-require
 
               // Clean up socket file if it exists
               try {
@@ -663,8 +658,8 @@ describe('#errorHandling', () => {
                 return done();
               }
 
-              // Mock unix-dgram socket to fail first `maxRetries` attempts, then succeed
-              const unixDgramModule = require('unix-dgram'); // eslint-disable-line global-require
+              // Mock unix-dgram-rs socket to fail first `maxRetries` attempts, then succeed
+              const unixDgramModule = require('unix_dgram_rs'); // eslint-disable-line global-require
               const realCreateSocket = unixDgramModule.createSocket;
               let sendAttempts = 0;
               unixDgramModule.createSocket = function(type) {
@@ -717,8 +712,8 @@ describe('#errorHandling', () => {
                return done();
               }
 
-              // Mock unix-dgram socket to always fail
-              const unixDgramModule = require('unix-dgram'); // eslint-disable-line global-require
+              // Mock unix_dgram_rs socket to always fail
+              const unixDgramModule = require('unix_dgram_rs'); // eslint-disable-line global-require
               const realCreateSocket = unixDgramModule.createSocket;
               unixDgramModule.createSocket = function(type) {
                 const realSocket = realCreateSocket(type);
@@ -793,7 +788,7 @@ describe('#errorHandling', () => {
                 }
                 cleanedUp = true;
                 udsServer.cleanup();
-                // restore unix-dgram createSocket if we patched it
+                // restore unix_dgram_rs createSocket if we patched it
                 try {
                   if (unixDgramModule && realCreateSocket) {
                     unixDgramModule.createSocket = realCreateSocket;
@@ -816,11 +811,11 @@ describe('#errorHandling', () => {
                 return done();
               }
 
-              // Monkey-patch unix-dgram socket to simulate buffer overflow (EAGAIN) at the socket level
+              // Monkey-patch unix_dgram_rs socket to simulate buffer overflow (EAGAIN) at the socket level
               // so that the transport's retry logic is exercised instead of being bypassed.
               try {
                 // eslint-disable-next-line global-require
-                unixDgramModule = require('unix-dgram');
+                unixDgramModule = require('unix_dgram_rs');
                 realCreateSocket = unixDgramModule.createSocket;
                 unixDgramModule.createSocket = function(type) {
                   const realSocket = realCreateSocket(type);
@@ -844,7 +839,7 @@ describe('#errorHandling', () => {
                   return realSocket;
                 };
               } catch (e) {
-                // If unix-dgram is not available, skip
+                // If unix_dgram_rs is not available, skip
                 return done();
               }
 

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -6,17 +6,8 @@ const os = require('os');
 const StatsD = require('../../lib/statsd.js');
 const EventEmitter = require('events');
 const { Writable } = require('stream');
+const unixDgram = require('unix_dgram_rs');
 const { STREAM, TCP, UDP, UDS } = require('../../lib/constants').PROTOCOL;
-let unixDgram;
-try {
-  // this will not always be available
-  unixDgram = require('unix-dgram'); // eslint-disable-line global-require
-}
-catch (err) {
-  if (os.platform() !== 'win32') {
-    console.error('Error installing unix-dgram: ', err);
-  }
-}
 
 const CLIENT = 'client';
 const CHILD_CLIENT = 'child client';


### PR DESCRIPTION
Hey! I recently rewrote the unix-dgram module using napi-rs and published it as a new package: https://github.com/hrhthegreat/unix_dgram_rs

This version no longer requires node-gyp during installation—prebuilt binaries are shipped with the package—and thanks to napi-rs, it’s compatible across Node.js versions without rebuilds.

The package currently supports Node.js ≥ 18. It’s published as 0.1.0-alpha.1, but it successfully passes the full test suite from the original unix-dgram. I’ve also tested it locally with hot-shots, and all tests are passing.

Would love your feedback!