### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node-test.js.yml
+++ b/.github/workflows/node-test.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/bdeitte/hot-shots/security/code-scanning/2](https://github.com/bdeitte/hot-shots/security/code-scanning/2)

To fix this, we should explicitly define a `permissions` block to restrict the `GITHUB_TOKEN` used by this workflow/job to the least privilege required. Since this CI workflow only needs to check out the repository and run builds/tests, it typically only requires `contents: read`. In many cases, you can even set `permissions: {}` or `permissions: read-all`, but the recommended minimal explicit permissions for this pattern is `contents: read`.

The best fix with minimal functional impact is to add a `permissions` block at the workflow root (so it applies to all jobs) just after the `on:` section, or at the `jobs.build` level. Here, adding it at the root is clean and clear: insert

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 6–10) and the `jobs:` block (line 12). No imports or additional methods are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
