### PR TITLE
Fix security alerts on testing dependencies

### DIFF
--- a/.github/workflows/node-test.js.yml
+++ b/.github/workflows/node-test.js.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16.x, 18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
-* @bdeitte Upgrade mocha from 10.x to 11.x and fix all dev dependency security vulnerabilities (serialize-javascript, diff, ajv)
+* @bdeitte Upgrade mocha from 10.x to 11.x and fix all dev dependency security vulnerabilities (serialize-javascript, ajv)
+* @bdeitte BREAKING: Drop Node.js 16 support, now requires Node.js >= 18.0.0
 
 ## 14.1.1 (2026-3-1)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ includes all changes in the latest node-statsd and many additional changes, incl
 
 You can read about all changes in [the changelog](CHANGES.md).
 
-hot-shots supports Node 16.x and higher. When using types.d.ts, hot-shots require TypeScript 4.0 or higher.
+hot-shots supports Node 18.x and higher. When using types.d.ts, hot-shots require TypeScript 4.0 or higher.
 
 ![Build Status](https://github.com/bdeitte/hot-shots/actions/workflows/node-test.js.yml/badge.svg)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "license": "MIT",
       "devDependencies": {
         "eslint": "8.x",
-        "mocha": "^11.7.5",
+        "mocha": "11.x",
         "nyc": "15.x",
         "sinon": "19.x"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "optionalDependencies": {
         "unix-dgram": "2.x"
@@ -1057,16 +1057,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -2137,6 +2127,16 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/mocha/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -2889,6 +2889,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/source-map": {
@@ -4171,12 +4181,6 @@
         "strip-bom": "^4.0.0"
       }
     },
-    "diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4923,7 +4927,7 @@
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^8.0.3",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
@@ -4934,7 +4938,7 @@
         "minimatch": "^9.0.5",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "7.x",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^9.2.0",
@@ -4951,6 +4955,12 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "diff": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+          "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+          "dev": true
         },
         "minimatch": {
           "version": "9.0.9",
@@ -5496,9 +5506,17 @@
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^13.0.5",
         "@sinonjs/samsam": "^8.0.1",
-        "diff": "^8.0.3",
+        "diff": "^7.0.0",
         "nise": "^6.1.1",
         "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+          "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+          "dev": true
+        }
       }
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lib": "./lib/"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "coverage": "nyc --reporter=lcov --reporter=text npm test",
@@ -47,7 +47,6 @@
   },
   "license": "MIT",
   "overrides": {
-    "serialize-javascript": "7.x",
-    "diff": "8.x"
+    "serialize-javascript": "7.x"
   }
 }


### PR DESCRIPTION
Upgrade mocha from 10.x to 11.x and fix all dev dependency security vulnerabilities (serialize-javascript, diff, ajv)