### PR TITLE
Fix TypeScript errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+* [@72636c](https://github.com/72636c) Omit Claude and GitHub dev files from bundle
+* [@bdeitte](https://github.com/bdeitte) Fix TypeScript error from ESM support changes and add TypeScript tests ([#316](https://github.com/bdeitte/hot-shots/issues/316))
+
 ## 14.3.0 (2026-4-3)
 
 * [@bdeitte](https://github.com/bdeitte) Add ESM support via `exports` field in package.json and `index.mjs` wrapper, enabling `import StatsD from 'hot-shots'` in ES module projects

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "14.3.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "^25.5.2",
         "eslint": "8.x",
         "mocha": "11.x",
         "nyc": "15.x",
-        "sinon": "19.x"
+        "sinon": "19.x",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -666,6 +668,16 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -3106,6 +3118,27 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unix-dgram": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.7.tgz",
@@ -3907,6 +3940,15 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.18.0"
+      }
     },
     "@ungap/structured-clone": {
       "version": "1.3.0",
@@ -5668,6 +5710,18 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
     },
     "unix-dgram": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./types.d.ts",
+        "types": "./types.d.mts",
         "default": "./index.mjs"
       },
       "require": {
@@ -54,10 +54,12 @@
     "unix-dgram": "2.x"
   },
   "devDependencies": {
+    "@types/node": "25.x",
     "eslint": "8.x",
     "mocha": "11.x",
     "nyc": "15.x",
-    "sinon": "19.x"
+    "sinon": "19.x",
+    "typescript": "5.x"
   },
   "license": "MIT",
   "overrides": {

--- a/test/typescript-compilation.js
+++ b/test/typescript-compilation.js
@@ -1,0 +1,202 @@
+'use strict';
+
+/* eslint-disable no-sync */
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+const os = require('os');
+
+const projectRoot = path.join(__dirname, '..');
+
+describe('#typescript', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hot-shots-ts-'));
+
+    // Create node_modules with hot-shots pointing to project root
+    const nmDir = path.join(tmpDir, 'node_modules');
+    fs.mkdirSync(nmDir);
+    fs.symlinkSync(projectRoot, path.join(nmDir, 'hot-shots'), 'junction');
+
+    // Symlink @types/node so tsc can resolve built-in modules
+    const typesDir = path.join(nmDir, '@types');
+    const srcTypesDir = path.join(projectRoot, 'node_modules', '@types');
+    if (fs.existsSync(srcTypesDir)) {
+      fs.symlinkSync(srcTypesDir, typesDir, 'junction');
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the TypeScript compiler against a temp directory.
+   * @param {object} tsconfig
+   * @param {string} code
+   */
+  function compileTs(tsconfig, code) {
+    fs.writeFileSync(
+      path.join(tmpDir, 'tsconfig.json'),
+      JSON.stringify(tsconfig, null, 2)
+    );
+    fs.writeFileSync(path.join(tmpDir, 'test.ts'), code);
+
+    const tscPath = path.join(projectRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+    try {
+      execFileSync(process.execPath, [tscPath, '--noEmit'], { cwd: tmpDir, encoding: 'utf8', stdio: 'pipe' });
+    }
+    catch (err) {
+      const output = (err.stdout || '') + (err.stderr || '');
+      assert.fail(`TypeScript compilation failed:\n${output}`);
+    }
+  }
+
+  it('should compile named import with moduleResolution NodeNext (ESM)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ type: 'module' }));
+    compileTs(
+      {
+        compilerOptions: {
+          target: 'esnext',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          noEmit: true,
+        },
+      },
+      [
+        'import { StatsD } from \'hot-shots\';',
+        'const client = new StatsD({ mock: true });',
+        'client.increment(\'test\');',
+        'client.close();',
+      ].join('\n')
+    );
+  });
+
+  it('should compile default import with moduleResolution NodeNext (ESM)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ type: 'module' }));
+    compileTs(
+      {
+        compilerOptions: {
+          target: 'esnext',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          noEmit: true,
+        },
+      },
+      [
+        'import HotShots from \'hot-shots\';',
+        'const client = new HotShots({ mock: true });',
+        'client.increment(\'test\');',
+        'client.close();',
+      ].join('\n')
+    );
+  });
+
+  it('should compile both import styles with moduleResolution NodeNext (ESM)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ type: 'module' }));
+    compileTs(
+      {
+        compilerOptions: {
+          target: 'esnext',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          noEmit: true,
+        },
+      },
+      [
+        'import HotShots, { StatsD } from \'hot-shots\';',
+        'const client = new HotShots({ mock: true });',
+        'const client2 = new StatsD({ mock: true });',
+        'client.increment(\'test\');',
+        'client2.increment(\'test\');',
+        'client.close();',
+        'client2.close();',
+      ].join('\n')
+    );
+  });
+
+  it('should compile with moduleResolution node (CJS)', () => {
+    compileTs(
+      {
+        compilerOptions: {
+          target: 'es2020',
+          module: 'commonjs',
+          moduleResolution: 'node',
+          strict: true,
+          esModuleInterop: true,
+          noEmit: true,
+        },
+      },
+      [
+        'import HotShots from \'hot-shots\';',
+        'import { StatsD } from \'hot-shots\';',
+        'const client = new HotShots({ mock: true });',
+        'const client2 = new StatsD({ mock: true });',
+        'client.increment(\'test\');',
+        'client2.increment(\'test\');',
+        'client.close();',
+        'client2.close();',
+      ].join('\n')
+    );
+  });
+
+  it('should compile with moduleResolution NodeNext (CJS)', () => {
+    compileTs(
+      {
+        compilerOptions: {
+          target: 'es2020',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          noEmit: true,
+        },
+      },
+      [
+        'import HotShots from \'hot-shots\';',
+        'import { StatsD } from \'hot-shots\';',
+        'const client = new HotShots({ mock: true });',
+        'const client2 = new StatsD({ mock: true });',
+        'client.increment(\'test\');',
+        'client2.increment(\'test\');',
+        'client.close();',
+        'client2.close();',
+      ].join('\n')
+    );
+  });
+
+  it('should compile with strict tsconfig matching issue #316', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ type: 'module' }));
+    compileTs(
+      {
+        compilerOptions: {
+          target: 'esnext',
+          lib: ['DOM', 'ESNext'],
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          allowSyntheticDefaultImports: true,
+          forceConsistentCasingInFileNames: true,
+          noImplicitOverride: true,
+          noImplicitReturns: true,
+          noFallthroughCasesInSwitch: true,
+          isolatedModules: true,
+          noEmit: true,
+        },
+      },
+      [
+        'import HotShots, { StatsD } from \'hot-shots\';',
+        'const client = new HotShots({ mock: true });',
+        'const client2 = new StatsD({ mock: true });',
+        'client.increment(\'test\');',
+        'client2.increment(\'test\');',
+        'client.close();',
+        'client2.close();',
+      ].join('\n')
+    );
+  });
+});

--- a/types.d.mts
+++ b/types.d.mts
@@ -1,0 +1,4 @@
+export { StatsD, Tags, ClientOptions, ChildClientOptions, CheckOptions, DatadogChecks, DatadogChecksValues, EventOptions, MetricOptions, TimerContext, StatsCb } from './types.js';
+import { StatsD, ClientOptions } from './types.js';
+declare const StatsDClient: new (options?: ClientOptions) => StatsD;
+export default StatsDClient;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,213 +1,210 @@
 import dgram = require("dgram");
 import stream = require("stream");
 
-declare module "hot-shots" {
-  export type Tags = { [key: string]: string } | string[];
-  export interface ClientOptions {
-    bufferFlushInterval?: number;
-    bufferHolder?: { buffer: string };
-    cacheDns?: boolean;
-    cacheDnsTtl?: number;
-    errorHandler?: (err: Error) => void;
-    globalTags?: Tags;
-    includeDataDogTags?: boolean;
-    globalize?: boolean;
-    host?: string;
-    isChild?: boolean;
-    maxBufferSize?: number;
-    mock?: boolean;
-    path?: string;
-    port?: number;
-    prefix?: string;
-    protocol?: 'tcp' | 'udp' | 'uds' | 'stream';
-    sampleRate?: number;
-    socket?: dgram.Socket;
-    stream?: stream.Writable;
-    suffix?: string;
-    telegraf?: boolean;
-    useDefaultRoute?: boolean;
-    tagPrefix?: string;
-    tagSeparator?: string;
-    tcpGracefulErrorHandling?: boolean;
-    tcpGracefulRestartRateLimit?: number;
-    udsGracefulErrorHandling?: boolean;
-    udsGracefulRestartRateLimit?: number;
-    closingFlushInterval?: number;
-    udpSocketOptions?: dgram.SocketOptions;
-    udsRetryOptions?: {
-      retries?: number;
-      retryDelayMs?: number;
-      maxRetryDelayMs?: number;
-      backoffFactor?: number;
-    };
-    includeDatadogTelemetry?: boolean;
-    telemetryFlushInterval?: number;
-  }
+export type Tags = { [key: string]: string } | string[];
+export interface ClientOptions {
+  bufferFlushInterval?: number;
+  bufferHolder?: { buffer: string };
+  cacheDns?: boolean;
+  cacheDnsTtl?: number;
+  errorHandler?: (err: Error) => void;
+  globalTags?: Tags;
+  includeDataDogTags?: boolean;
+  globalize?: boolean;
+  host?: string;
+  isChild?: boolean;
+  maxBufferSize?: number;
+  mock?: boolean;
+  path?: string;
+  port?: number;
+  prefix?: string;
+  protocol?: 'tcp' | 'udp' | 'uds' | 'stream';
+  sampleRate?: number;
+  socket?: dgram.Socket;
+  stream?: stream.Writable;
+  suffix?: string;
+  telegraf?: boolean;
+  useDefaultRoute?: boolean;
+  tagPrefix?: string;
+  tagSeparator?: string;
+  tcpGracefulErrorHandling?: boolean;
+  tcpGracefulRestartRateLimit?: number;
+  udsGracefulErrorHandling?: boolean;
+  udsGracefulRestartRateLimit?: number;
+  closingFlushInterval?: number;
+  udpSocketOptions?: dgram.SocketOptions;
+  udsRetryOptions?: {
+    retries?: number;
+    retryDelayMs?: number;
+    maxRetryDelayMs?: number;
+    backoffFactor?: number;
+  };
+  includeDatadogTelemetry?: boolean;
+  telemetryFlushInterval?: number;
+}
 
-  export interface ChildClientOptions {
-    globalTags?: Tags;
-    prefix?: string;
-    suffix?: string;
-    errorHandler?: (err: Error) => void;
-  }
+export interface ChildClientOptions {
+  globalTags?: Tags;
+  prefix?: string;
+  suffix?: string;
+  errorHandler?: (err: Error) => void;
+}
 
-  export interface CheckOptions {
-    date_happened?: Date;
-    hostname?: string;
-    message?: string;
-  }
+export interface CheckOptions {
+  date_happened?: Date;
+  hostname?: string;
+  message?: string;
+}
 
-  export interface DatadogChecks {
-    OK: 0;
-    WARNING: 1;
-    CRITICAL: 2;
-    UNKNOWN: 3;
-  }
+export interface DatadogChecks {
+  OK: 0;
+  WARNING: 1;
+  CRITICAL: 2;
+  UNKNOWN: 3;
+}
 
-  type unionFromInterfaceValues4<
-    T,
-    K1 extends keyof T,
-    K2 extends keyof T,
-    K3 extends keyof T,
-    K4 extends keyof T,
-    > = T[K1] | T[K2] | T[K3] | T[K4];
+type unionFromInterfaceValues4<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T,
+  K3 extends keyof T,
+  K4 extends keyof T,
+  > = T[K1] | T[K2] | T[K3] | T[K4];
 
-  export type DatadogChecksValues = unionFromInterfaceValues4<DatadogChecks, "OK", "WARNING", "CRITICAL", "UNKNOWN">;
+export type DatadogChecksValues = unionFromInterfaceValues4<DatadogChecks, "OK", "WARNING", "CRITICAL", "UNKNOWN">;
 
-  export interface EventOptions {
-    aggregation_key?: string;
-    alert_type?: "info" | "warning" | "success" | "error";
-    date_happened?: Date;
-    hostname?: string;
-    priority?: "low" | "normal";
-    source_type_name?: string;
-  }
+export interface EventOptions {
+  aggregation_key?: string;
+  alert_type?: "info" | "warning" | "success" | "error";
+  date_happened?: Date;
+  hostname?: string;
+  priority?: "low" | "normal";
+  source_type_name?: string;
+}
 
-  export interface MetricOptions {
-    sampleRate?: number;
-    tags?: Tags;
-    /** Timestamp for the metric (DogStatsD only). Can be a Date or Unix timestamp in seconds. */
-    timestamp?: Date | number;
-  }
+export interface MetricOptions {
+  sampleRate?: number;
+  tags?: Tags;
+  /** Timestamp for the metric (DogStatsD only). Can be a Date or Unix timestamp in seconds. */
+  timestamp?: Date | number;
+}
+
+/**
+ * Context object passed to timer/asyncTimer/asyncDistTimer wrapped functions.
+ * Allows adding tags dynamically during function execution.
+ */
+export interface TimerContext {
+  /**
+   * Add tags to be included when the metric is recorded.
+   * Can be called multiple times to accumulate tags.
+   * @param tags Tags to add. Can be an object like {key: 'value'} or array like ['key:value']
+   */
+  addTags(tags: Tags): void;
+}
+
+export type StatsCb = (error?: Error, bytes?: number) => void;
+
+export class StatsD {
+  constructor(options?: ClientOptions);
+  childClient(options?: ChildClientOptions): StatsD;
+
+  increment(stat: string, tags?: Tags): void;
+  increment(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  increment(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
+
+  decrement(stat: string): void;
+  decrement(stat: string, tags?: Tags): void;
+  decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  decrement(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
+
+  timing(stat: string | string[], value: number | Date, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number | Date, tags?: Tags, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number | Date, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number | Date, sampleRate?: number, callback?: StatsCb): void;
+  timing(stat: string | string[], value: number | Date, options?: MetricOptions, callback?: StatsCb): void;
 
   /**
-   * Context object passed to timer/asyncTimer/asyncDistTimer wrapped functions.
-   * Allows adding tags dynamically during function execution.
+   * Wraps a function to record its execution time. The wrapped function receives a TimerContext
+   * as its last argument, which can be used to add tags dynamically during execution.
    */
-  export interface TimerContext {
-    /**
-     * Add tags to be included when the metric is recorded.
-     * Can be called multiple times to accumulate tags.
-     * @param tags Tags to add. Can be an object like {key: 'value'} or array like ['key:value']
-     */
-    addTags(tags: Tags): void;
-  }
+  timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => R;
+  timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => R;
+  timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], callback?: StatsCb): (...args: P) => R;
+  timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => R;
+  timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], options?: MetricOptions, callback?: StatsCb): (...args: P) => R;
 
-  export type StatsCb = (error?: Error, bytes?: number) => void;
+  /**
+   * Wraps an async function to record its execution time. The wrapped function receives a TimerContext
+   * as its last argument, which can be used to add tags dynamically during execution.
+   */
+  asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], options?: MetricOptions, callback?: StatsCb): (...args: P) => Promise<R>;
 
-  export class StatsD {
-    constructor(options?: ClientOptions);
-    childClient(options?: ChildClientOptions): StatsD;
+  /**
+   * Wraps an async function to record its execution time as a distribution. The wrapped function receives
+   * a TimerContext as its last argument, which can be used to add tags dynamically during execution.
+   */
+  asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => Promise<R>;
+  asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], options?: MetricOptions, callback?: StatsCb): (...args: P) => Promise<R>;
 
-    increment(stat: string, tags?: Tags): void;
-    increment(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-    increment(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  histogram(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
 
-    decrement(stat: string): void;
-    decrement(stat: string, tags?: Tags): void;
-    decrement(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-    decrement(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  distribution(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
 
-    timing(stat: string | string[], value: number | Date, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number | Date, tags?: Tags, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number | Date, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number | Date, sampleRate?: number, callback?: StatsCb): void;
-    timing(stat: string | string[], value: number | Date, options?: MetricOptions, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  gauge(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
 
-    /**
-     * Wraps a function to record its execution time. The wrapped function receives a TimerContext
-     * as its last argument, which can be used to add tags dynamically during execution.
-     */
-    timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => R;
-    timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => R;
-    timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], callback?: StatsCb): (...args: P) => R;
-    timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => R;
-    timer<P extends any[], R>(func: (...args: [...P, TimerContext]) => R, stat: string | string[], options?: MetricOptions, callback?: StatsCb): (...args: P) => R;
+  gaugeDelta(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  gaugeDelta(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
+  gaugeDelta(stat: string | string[], value: number, callback?: StatsCb): void;
+  gaugeDelta(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
+  gaugeDelta(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
 
-    /**
-     * Wraps an async function to record its execution time. The wrapped function receives a TimerContext
-     * as its last argument, which can be used to add tags dynamically during execution.
-     */
-    asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], options?: MetricOptions, callback?: StatsCb): (...args: P) => Promise<R>;
+  set(stat: string | string[], value: number | string, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  set(stat: string | string[], value: number | string, tags?: Tags, callback?: StatsCb): void;
+  set(stat: string | string[], value: number | string, callback?: StatsCb): void;
+  set(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
+  set(stat: string | string[], value: number | string, options?: MetricOptions, callback?: StatsCb): void;
 
-    /**
-     * Wraps an async function to record its execution time as a distribution. The wrapped function receives
-     * a TimerContext as its last argument, which can be used to add tags dynamically during execution.
-     */
-    asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], tags?: Tags, callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], sampleRate?: number, callback?: StatsCb): (...args: P) => Promise<R>;
-    asyncDistTimer<P extends any[], R>(func: (...args: [...P, TimerContext]) => Promise<R>, stat: string | string[], options?: MetricOptions, callback?: StatsCb): (...args: P) => Promise<R>;
+  unique(stat: string | string[], value: number | string, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number | string, tags?: Tags, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number | string, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
+  unique(stat: string | string[], value: number | string, options?: MetricOptions, callback?: StatsCb): void;
 
-    histogram(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-    histogram(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
+  close(callback?: (error?: Error) => void): void;
 
-    distribution(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-    distribution(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
+  event(title: string, text?: string, options?: EventOptions, tags?: Tags, callback?: StatsCb): void;
+  event(title: string, text?: string, options?: EventOptions, callback?: StatsCb): void;
+  check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
 
-    gauge(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-    gauge(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
-
-    gaugeDelta(stat: string | string[], value: number, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    gaugeDelta(stat: string | string[], value: number, tags?: Tags, callback?: StatsCb): void;
-    gaugeDelta(stat: string | string[], value: number, callback?: StatsCb): void;
-    gaugeDelta(stat: string | string[], value: number, sampleRate?: number, callback?: StatsCb): void;
-    gaugeDelta(stat: string | string[], value: number, options?: MetricOptions, callback?: StatsCb): void;
-
-    set(stat: string | string[], value: number | string, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    set(stat: string | string[], value: number | string, tags?: Tags, callback?: StatsCb): void;
-    set(stat: string | string[], value: number | string, callback?: StatsCb): void;
-    set(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
-    set(stat: string | string[], value: number | string, options?: MetricOptions, callback?: StatsCb): void;
-
-    unique(stat: string | string[], value: number | string, sampleRate?: number, tags?: Tags, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number | string, tags?: Tags, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number | string, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number | string, sampleRate?: number, callback?: StatsCb): void;
-    unique(stat: string | string[], value: number | string, options?: MetricOptions, callback?: StatsCb): void;
-
-    close(callback?: (error?: Error) => void): void;
-
-    event(title: string, text?: string, options?: EventOptions, tags?: Tags, callback?: StatsCb): void;
-    event(title: string, text?: string, options?: EventOptions, callback?: StatsCb): void;
-    check(name: string, status: DatadogChecksValues, options?: CheckOptions, tags?: Tags, callback?: StatsCb): void;
-
-    public CHECKS: DatadogChecks;
-    public mockBuffer?: string[];
-    public socket: dgram.Socket;
-  }
+  public CHECKS: DatadogChecks;
+  public mockBuffer?: string[];
+  public socket: dgram.Socket;
 }
 
 declare const StatsDClient: new (options?: ClientOptions) => StatsD;
 export default StatsDClient;
-export { StatsD };


### PR DESCRIPTION
Move type declarations from inside `declare module "hot-shots"` to file scope so they are directly exportable. Add `types.d.mts` for proper ESM type resolution and point the package.json ESM types condition to it. Add TypeScript compilation tests covering NodeNext and CJS resolution.  Fixes https://github.com/bdeitte/hot-shots/issues/316 