### PR TITLE
Fix UDS graceful restart for unix-dgram numeric errcodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+* Fix UDS graceful restart never firing for unix-dgram errors: `udsErrors()` now includes negative numeric errno codes (`-107`/`-111` on Linux, `-39`/`-54` on Darwin) alongside the existing string codes. unix-dgram sets `err.code` to a negative number (e.g. `-107`), so the string-only check introduced in v14 for #301/#302 could never match and sockets were never replaced after Agent UDS inode churn.
+
 ## 17.0.0 (2026-7-11)
 
 * [@bdeitte](https://github.com/bdeitte) Add opt-in client-side aggregation of counts, gauges and sets via the `aggregation` option, for better parity with official DogStatsD clients but also for use with any StatsD, DogStatsD or Telegraf client. This includes an aggregation `maxContexts` option (default 5000) bounding the number of live aggregation contexts; new contexts beyond the cap are sent directly with a one-time warning.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,17 +28,24 @@ function tcpErrors() {
 
 /**
  * Determines error codes that signify a connection to a Unix Domain Socket (UDS)
- * has failed in a way that can be retried. These are string error codes
- * matching Node.js socket error.code values. OS-specific.
- * @returns {string[]} An array of the error codes.
+ * has failed in a way that can be retried. OS-specific.
+ *
+ * Includes both:
+ * - string Node.js-style codes (e.g. 'ENOTCONN'), and
+ * - negative numeric errnos from unix-dgram (e.g. -107 on Linux for ENOTCONN),
+ *   which sets `err.code = errorno` rather than a string name.
+ *
+ * @returns {Array<string|number>} An array of the error codes.
  */
 function udsErrors() {
   if (process.platform === 'linux') {
-    return ['ENOTCONN', 'ECONNREFUSED'];
+    // unix-dgram reports negative numeric errnos, not string codes
+    return ['ENOTCONN', 'ECONNREFUSED', -107, -111];
   }
 
   if (process.platform === 'darwin') {
-    return ['EDESTADDRREQ', 'ECONNRESET'];
+    // unix-dgram reports negative numeric errnos, not string codes
+    return ['EDESTADDRREQ', 'ECONNRESET', -39, -54];
   }
 
   // Unknown / not yet implemented

--- a/test/constants.js
+++ b/test/constants.js
@@ -42,11 +42,17 @@ describe('#constants', () => {
       if (process.platform === 'linux') {
         assert.ok(errors.includes('ENOTCONN'));
         assert.ok(errors.includes('ECONNREFUSED'));
-        assert.strictEqual(errors.length, 2);
+        // unix-dgram sets err.code to negative errno (ENOTCONN=107, ECONNREFUSED=111)
+        assert.ok(errors.includes(-107));
+        assert.ok(errors.includes(-111));
+        assert.strictEqual(errors.length, 4);
       } else if (process.platform === 'darwin') {
         assert.ok(errors.includes('EDESTADDRREQ'));
         assert.ok(errors.includes('ECONNRESET'));
-        assert.strictEqual(errors.length, 2);
+        // unix-dgram sets err.code to negative errno (EDESTADDRREQ=39, ECONNRESET=54)
+        assert.ok(errors.includes(-39));
+        assert.ok(errors.includes(-54));
+        assert.strictEqual(errors.length, 4);
       } else {
         // Unknown platforms return empty array
         assert.strictEqual(errors.length, 0);


### PR DESCRIPTION
## Summary

`udsGracefulErrorHandling` never recreates the socket on hot-shots ≥14 when using `unix-dgram`, because `protocolErrorHandler` compares `err.code` against **string** codes only (`'ENOTCONN'`, …), while `unix-dgram` sets `err.code` to a **negative numeric errno** (e.g. `-107` / `-111` on Linux, `-39` / `-54` on Darwin).

This is the UDS follow-on to #301 / #302: the TCP string-code fix was correct for Node TCP sockets, but the same change broke UDS matching.

### Fix

Minimal change in `udsErrors()`: keep the existing string codes and also include the negative numeric errnos that `unix-dgram` emits.

```js
// linux
return ['ENOTCONN', 'ECONNREFUSED', -107, -111];
// darwin
return ['EDESTADDRREQ', 'ECONNRESET', -39, -54];
```

## Test plan

- [x] `npm install`
- [x] `npm test` — 1957 passing
- [x] Updated `test/constants.js` assertions for numeric codes
- [x] CI on this PR

## Related

Follow-up to #301 / #302 (UDS path).


Made with [Cursor](https://cursor.com)