### PR TITLE
Harden UDS numeric-errno fix: derive errnos + add regression test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## Unreleased
 
-* [@KeenanLawrenceStitch](https://github.com/KeenanLawrenceStitch) Fix UDS graceful restart never firing for unix-dgram errors: `udsErrors()` now includes the negative numeric errno codes (e.g. `-111` on Linux, `-54` on Darwin) that unix-dgram sets on `err.code`, alongside the existing string codes. The errnos are derived from `os.constants.errno` so they stay correct across architectures. The string-only check introduced in v14 for [#301](https://github.com/bdeitte/hot-shots/issues/301) / [#302](https://github.com/bdeitte/hot-shots/issues/302) could never match unix-dgram's numeric codes, so sockets were never replaced after Agent UDS inode churn. See [#322](https://github.com/bdeitte/hot-shots/issues/322) / [#323](https://github.com/bdeitte/hot-shots/issues/323).
+* [@KeenanLawrenceStitch](https://github.com/KeenanLawrenceStitch) Fix UDS graceful restart never firing for unix-dgram errors: `udsErrors()` now includes the negative numeric errno codes (e.g. `-111` on Linux, `-54` on Darwin) that unix-dgram sets on `err.code`, alongside the existing string codes. See [#322](https://github.com/bdeitte/hot-shots/issues/322)
 
 ## 17.0.0 (2026-7-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## Unreleased
 
-* Fix UDS graceful restart never firing for unix-dgram errors: `udsErrors()` now includes negative numeric errno codes (`-107`/`-111` on Linux, `-39`/`-54` on Darwin) alongside the existing string codes. unix-dgram sets `err.code` to a negative number (e.g. `-107`), so the string-only check introduced in v14 for #301/#302 could never match and sockets were never replaced after Agent UDS inode churn.
+* [@KeenanLawrenceStitch](https://github.com/KeenanLawrenceStitch) Fix UDS graceful restart never firing for unix-dgram errors: `udsErrors()` now includes the negative numeric errno codes (e.g. `-111` on Linux, `-54` on Darwin) that unix-dgram sets on `err.code`, alongside the existing string codes. The errnos are derived from `os.constants.errno` so they stay correct across architectures. The string-only check introduced in v14 for [#301](https://github.com/bdeitte/hot-shots/issues/301) / [#302](https://github.com/bdeitte/hot-shots/issues/302) could never match unix-dgram's numeric codes, so sockets were never replaced after Agent UDS inode churn. See [#322](https://github.com/bdeitte/hot-shots/issues/322) / [#323](https://github.com/bdeitte/hot-shots/issues/323).
 
 ## 17.0.0 (2026-7-11)
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const process = require('process');
 
 exports.PROTOCOL = {
@@ -35,17 +36,23 @@ function tcpErrors() {
  * - negative numeric errnos from unix-dgram (e.g. -107 on Linux for ENOTCONN),
  *   which sets `err.code = errorno` rather than a string name.
  *
+ * The numeric errnos are derived from `os.constants.errno` rather than
+ * hardcoded, so they stay correct on architectures whose errno values differ
+ * from the common x86/arm ones (e.g. mips/sparc Linux).
+ *
  * @returns {Array<string|number>} An array of the error codes.
  */
 function udsErrors() {
+  const errno = os.constants.errno;
+
   if (process.platform === 'linux') {
     // unix-dgram reports negative numeric errnos, not string codes
-    return ['ENOTCONN', 'ECONNREFUSED', -107, -111];
+    return ['ENOTCONN', 'ECONNREFUSED', -errno.ENOTCONN, -errno.ECONNREFUSED];
   }
 
   if (process.platform === 'darwin') {
     // unix-dgram reports negative numeric errnos, not string codes
-    return ['EDESTADDRREQ', 'ECONNRESET', -39, -54];
+    return ['EDESTADDRREQ', 'ECONNRESET', -errno.EDESTADDRREQ, -errno.ECONNRESET];
   }
 
   // Unknown / not yet implemented

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const constants = require('../lib/constants');
+const os = require('os');
 
 describe('#constants', () => {
   describe('PROTOCOL', () => {
@@ -39,19 +40,20 @@ describe('#constants', () => {
 
     it('should return platform-specific error codes', () => {
       const errors = constants.udsErrors();
+      const errno = os.constants.errno;
       if (process.platform === 'linux') {
         assert.ok(errors.includes('ENOTCONN'));
         assert.ok(errors.includes('ECONNREFUSED'));
-        // unix-dgram sets err.code to negative errno (ENOTCONN=107, ECONNREFUSED=111)
-        assert.ok(errors.includes(-107));
-        assert.ok(errors.includes(-111));
+        // unix-dgram sets err.code to the negative errno (e.g. -107 for ENOTCONN)
+        assert.ok(errors.includes(-errno.ENOTCONN));
+        assert.ok(errors.includes(-errno.ECONNREFUSED));
         assert.strictEqual(errors.length, 4);
       } else if (process.platform === 'darwin') {
         assert.ok(errors.includes('EDESTADDRREQ'));
         assert.ok(errors.includes('ECONNRESET'));
-        // unix-dgram sets err.code to negative errno (EDESTADDRREQ=39, ECONNRESET=54)
-        assert.ok(errors.includes(-39));
-        assert.ok(errors.includes(-54));
+        // unix-dgram sets err.code to the negative errno (e.g. -54 for ECONNRESET)
+        assert.ok(errors.includes(-errno.EDESTADDRREQ));
+        assert.ok(errors.includes(-errno.ECONNRESET));
         assert.strictEqual(errors.length, 4);
       } else {
         // Unknown platforms return empty array

--- a/test/errorHandling.js
+++ b/test/errorHandling.js
@@ -437,6 +437,42 @@ describe('#errorHandling', () => {
             });
           });
 
+          it('should re-create the socket on numeric unix-dgram errno for type uds', function (done) {
+            const code = badUDSNumericCode();
+            if (code === null) {
+              // No known unix-dgram numeric errno for this platform
+              this.skip();
+              return;
+            }
+            Date.now = () => '4857394578';
+            // emit an error, like the real unix-dgram transport would: err.code
+            // is a negative numeric errno, not a string name (regression for the
+            // v14 string-only check that never matched unix-dgram errors)
+            server = createServer('uds_broken', opts => {
+              const client = statsd = createHotShotsClient(Object.assign(opts, {
+                protocol: 'uds',
+                errorHandler(error) {
+                  assert.ok(error);
+                  assert.strictEqual(error.code, code);
+                }
+              }), 'client');
+              const initialSocket = client.socket;
+              setTimeout(() => {
+                initialSocket.emit('error', { code });
+                assert.ok(Object.is(initialSocket, client.socket));
+                // it should not create the socket if it breaks too quickly
+                // change time and make another error
+                Date.now = () => 4857394578 + 1000; // 1 second later
+                initialSocket.emit('error', { code });
+                setTimeout(() => {
+                  // make sure the socket was re-created
+                  assert.notEqual(initialSocket, client.socket);
+                  done();
+                }, 5);
+              }, 5);
+            });
+          });
+
           it('should re-create the socket on bad descriptor error for type uds', (done) => {
             const code = badUDSDescriptorCode();
             Date.now = () => '4857394578';
@@ -980,4 +1016,27 @@ function badUDSDescriptorCode() {
   }
 
   return 'not-implemented';
+}
+
+/**
+ * Return the negative numeric errno that `unix-dgram` sets on `err.code` for a
+ * "bad connection" UDS failure. unix-dgram does `err.code = errorno` where
+ * errorno is a negative errno (e.g. -111 for ECONNREFUSED on Linux), not a
+ * string name. This is the code the real UDS transport produces.
+ *
+ * - -ECONNREFUSED on Linux
+ * - -ECONNRESET on macOS
+ * - null on other platforms
+ */
+function badUDSNumericCode() {
+  const errno = require('os').constants.errno; // eslint-disable-line global-require
+  if (process.platform === 'linux') {
+    return -errno.ECONNREFUSED;
+  }
+
+  if (process.platform === 'darwin') {
+    return -errno.ECONNRESET;
+  }
+
+  return null;
 }


### PR DESCRIPTION
Follow-up to #322 / #323. The merged fix in #323 works on mainstream x86/arm Linux and macOS, but this makes a few more updates:

1. Derive the errnos from `os.constants.errno` instead of hardcoding. Deriving from `os.constants.errno` produces the identical values on x86/arm while staying correct everywhere.
2. Add a full regression test
3. Derive expected values in the constants test too, so it can't drift from the implementation on non-x86 platforms
