### PR TITLE
Support whitespace-delimited DD_TAGS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+* [@bdeitte](https://github.com/bdeitte) Parse whitespace-delimited `DD_TAGS` / `DATADOG_TAGS` values: when the value contains no comma, whitespace is used as the separator, matching `dd-trace-js` and the Datadog Agent. See [#325](https://github.com/bdeitte/hot-shots/issues/325)
+
 ## 17.0.1 (2026-7-18)
 
 * [@KeenanLawrenceStitch](https://github.com/KeenanLawrenceStitch) Fix UDS graceful restart never firing for unix-dgram errors: `udsErrors()` now includes the negative numeric errno codes (e.g. `-111` on Linux, `-54` on Darwin) that unix-dgram sets on `err.code`, alongside the existing string codes. See [#322](https://github.com/bdeitte/hot-shots/issues/322)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Parameters (specified as one object passed into hot-shots):
   * `service` from `DD_SERVICE` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
   * `version` from `DD_VERSION` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
 
-  In addition, comma-delimited tags from the `DD_TAGS` environment variable (or its legacy alias `DATADOG_TAGS`) are added to `globalTags`. For example `DD_TAGS=rack:1,team:core` adds `rack:1` and `team:core`. These are applied before the `DD_ENV`/`DD_SERVICE`/`DD_VERSION` mapping above, so those env vars win on a key conflict.
+  In addition, tags from the `DD_TAGS` environment variable (or its legacy alias `DATADOG_TAGS`) are added to `globalTags`. For example `DD_TAGS=rack:1,team:core` adds `rack:1` and `team:core`. If the value contains no comma, whitespace is used as the separator instead, matching `dd-trace-js` and the Datadog Agent, so `DD_TAGS="env:staging service:my-service"` adds `env:staging` and `service:my-service`. These are applied before the `DD_ENV`/`DD_SERVICE`/`DD_VERSION` mapping above, so those env vars win on a key conflict.
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0` for udp and tcp.  `default: 8192` for uds.
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Parameters (specified as one object passed into hot-shots):
   * `service` from `DD_SERVICE` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
   * `version` from `DD_VERSION` ([docs](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes#full-configuration))
 
-  In addition, tags from the `DD_TAGS` environment variable (or its legacy alias `DATADOG_TAGS`) are added to `globalTags`. For example `DD_TAGS=rack:1,team:core` adds `rack:1` and `team:core`. If the value contains no comma, whitespace is used as the separator instead, matching `dd-trace-js` and the Datadog Agent, so `DD_TAGS="env:staging service:my-service"` adds `env:staging` and `service:my-service`. These are applied before the `DD_ENV`/`DD_SERVICE`/`DD_VERSION` mapping above, so those env vars win on a key conflict.
+  In addition, tags from the `DD_TAGS` environment variable (or its legacy alias `DATADOG_TAGS`) are added to `globalTags`. For example `DD_TAGS=rack:1,team:core` adds `rack:1` and `team:core`. If the value contains no comma, whitespace is used as the separator instead, matching `dd-trace-js` and the Datadog Agent, so `DD_TAGS="env:staging service:my-service"` adds `env:staging` and `service:my-service`. These are applied before the `DD_ENV`/`DD_SERVICE`/`DD_VERSION` mapping above.
 * `maxBufferSize`: If larger than 0,  metrics will be buffered and only sent when the string length is greater than the size. `default: 0` for udp and tcp.  `default: 8192` for uds.
 * `bufferFlushInterval`: If buffering is in use, this is the time in ms to always flush any buffered metrics. `default: 1000`
 * `telegraf`:    Use Telegraf's StatsD line protocol, which is slightly different than the rest `default: false`
@@ -128,10 +128,10 @@ Precedence is: explicit transport options > `DD_DOGSTATSD_URL` > `DD_DOGSTATSD_S
 * `udpSocketOptions`: Used only when the protocol is `udp`. Specify the options passed into dgram.createSocket(). The socket type (`udp4` or `udp6`) is auto-detected based on the host: IPv6 addresses (e.g., `::1`) use `udp6`, IPv4 addresses use `udp4`, and hostnames default to `udp4`. You can override auto-detection by explicitly setting `type` (e.g., `{ type: 'udp6' }`).
 * `includeDatadogTelemetry`: Enable client-side telemetry to track metrics about the client itself. This helps diagnose high-throughput metric delivery issues. Telemetry metrics are prefixed with `datadog.dogstatsd.client.` and are not billed as custom metrics. `default: false`, except it defaults to `true` whenever Datadog mode is active (an explicit `datadog: true` or one of the Datadog signal env vars listed under the `datadog` option). An explicit value always wins. See [Client-Side Telemetry](#client-side-telemetry) for details.
 * `telemetryFlushInterval`: When telemetry is enabled, how often (in ms) to send telemetry metrics. `default: 10000`
-* `datadog`: Enable Datadog mode, turning on origin detection (`|c:`), External Data (`|e:`), cardinality (`|card:`), and client telemetry. Pass `true`/`false` to force it (like `telegraf`). When unset, it auto-detects: enabled when not using `telegraf` and a Datadog signal env var is set (`DD_AGENT_HOST`, `DD_DOGSTATSD_PORT`, `DD_ENTITY_ID`, `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, `DD_EXTERNAL_ENV`, `DD_CARDINALITY`, `DD_TAGS`, `DD_DOGSTATSD_URL`, `DD_DOGSTATSD_SOCKET`). Note that the legacy `DATADOG_TAGS` alias does **not** auto-enable Datadog mode — only `DD_TAGS` is treated as a signal. The `uds` protocol alone does **not** auto-enable Datadog mode — set `datadog: true` explicitly if you want it. `default: auto-detect`
+* `datadog`: Enable Datadog mode, turning on origin detection (`|c:`), External Data (`|e:`), cardinality (`|card:`), and client telemetry. Pass `true`/`false` to force it. When unset, it auto-detects: enabled when not using `telegraf` and a Datadog signal env var is set (`DD_AGENT_HOST`, `DD_DOGSTATSD_PORT`, `DD_ENTITY_ID`, `DD_ENV`, `DD_SERVICE`, `DD_VERSION`, `DD_EXTERNAL_ENV`, `DD_CARDINALITY`, `DD_TAGS`, `DD_DOGSTATSD_URL`, `DD_DOGSTATSD_SOCKET`). Note that the legacy `DATADOG_TAGS` alias does not auto-enable Datadog mode, as only `DD_TAGS` is treated as a signal. The `uds` protocol alone also does not auto-enable Datadog mode. `default: auto-detect`
 * `originDetection`: When in Datadog mode, auto-detect the container ID from cgroups and send it as `|c:` for [origin detection](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp). Respects `DD_ORIGIN_DETECTION_ENABLED`. Linux only. `default: true in datadog mode`
 * `containerID`: Manually set the container ID (skips cgroup parsing). Only used in Datadog mode. `default: undefined`
-* `cardinality`: Client-wide default tag cardinality sent as `|card:` — one of `none`, `low`, `orchestrator`, `high`. Falls back to the `DD_CARDINALITY` / `DATADOG_CARDINALITY` env var. Only used in Datadog mode. `default: undefined`
+* `cardinality`: Client-wide default tag cardinality sent as `|card:` one of `none`, `low`, `orchestrator`, `high`. Falls back to the `DD_CARDINALITY` / `DATADOG_CARDINALITY` env var. Only used in Datadog mode. `default: undefined`
 * `aggregation`: Enable client-side aggregation of counts, gauges and sets before sending, reducing packet volume for hot metrics. Pass `true` to enable with defaults, or an object `{ flushInterval, maxContexts }` to configure the flush interval (ms, `default: 2000`) and the max distinct contexts held per flush window (`default: 5000`). `default: false`. See [Client-side aggregation](#client-side-aggregation) for details.
 
 ### StatsD methods
@@ -399,7 +399,7 @@ Take a look at the [Datadog docs](https://docs.datadoghq.com/developers/dogstats
 
 ### Sending metrics during process shutdown
 
-Metrics sent from `process.on('exit')` handlers will **not** be delivered. This is a fundamental Node.js limitation, not a bug in hot-shots. When the `exit` event fires, the event loop has stopped processing async operations, so socket send callbacks will never execute.
+Metrics sent from `process.on('exit')` handlers will not be delivered. This is a fundamental Node.js limitation, not a bug in hot-shots. When the `exit` event fires, the event loop has stopped processing async operations, so socket send callbacks will never execute.
 
 The same applies to `process.on('uncaughtExceptionMonitor')` since that handler is also synchronous.
 
@@ -460,10 +460,10 @@ Some of the functionality mentioned above is specific to certain backends and wi
 
 When talking to a Datadog Agent, enable Datadog mode to get similar behavior as the official Datadog clients. Datadog mode adds three Datadog protocol-extension fields and turns client telemetry on:
 
-* **Origin detection** (`|c:`) — the container ID is auto-detected from cgroups (Linux only) for [origin detection](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp). Disable with `originDetection: false` or `DD_ORIGIN_DETECTION_ENABLED=false`; override with `containerID`.
-* **External Data** (`|e:`) — read from the `DD_EXTERNAL_ENV` environment variable (injected by the Datadog Admission Controller).
-* **Cardinality** (`|card:`) — set a client-wide default via `cardinality` or `DD_CARDINALITY`, or per metric/event/check via the options object.
-* **Telemetry** — `includeDatadogTelemetry` defaults to `true` whenever datadog mode is active (an explicit `datadog: true` or one of the Datadog signal env vars listed under the `datadog` option above). Because the `uds` protocol alone no longer auto-enables datadog mode, bare `uds` clients stay off by default. Set it to `false` to opt out, or `true` to force it on.
+* Origin detection (`|c:`) — the container ID is auto-detected from cgroups (Linux only) for [origin detection](https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp). Disable with `originDetection: false` or `DD_ORIGIN_DETECTION_ENABLED=false`; override with `containerID`.
+* External Data (`|e:`) — read from the `DD_EXTERNAL_ENV` environment variable (injected by the Datadog Admission Controller).
+* Cardinality (`|card:`) — set a client-wide default via `cardinality` or `DD_CARDINALITY`, or per metric/event/check via the options object.
+* Telemetry — `includeDatadogTelemetry` defaults to `true` whenever datadog mode is active (an explicit `datadog: true` or one of the Datadog signal env vars listed under the `datadog` option above). Because the `uds` protocol alone no longer auto-enables datadog mode, bare `uds` clients stay off by default. Set it to `false` to opt out, or `true` to force it on.
 
 Datadog mode never activates for `telegraf` clients, and adds no extension fields when off, so non-Datadog (StatsD/Telegraf/OpenTelemetry) usage is unaffected.
 
@@ -569,7 +569,7 @@ When enabled, metrics are combined per context (metric type, name, per-call tags
 * Gauges keep the most recent value.
 * Sets emit each unique value once.
 
-The following always bypass aggregation and are sent immediately: histograms, distributions, timings, events and service checks, plus any count/gauge/set that uses a *per-call* sample rate, a timestamp, a delta gauge (`+`/`-` value), or a `NaN` value. A client-level default `sampleRate` does **not** disable aggregation. Child clients share the parent's aggregator instance; clients that differ in their global tags or default cardinality aggregate into separate contexts.
+The following always bypass aggregation and are sent immediately: histograms, distributions, timings, events and service checks, plus any count/gauge/set that uses a *per-call* sample rate, a timestamp, a delta gauge (`+`/`-` value), or a `NaN` value. A client-level default `sampleRate` does not disable aggregation. Child clients share the parent's aggregator instance; clients that differ in their global tags or default cardinality aggregate into separate contexts.
 
 The per-metric callback fires synchronously when a metric is aggregated, as a "queued" signal (the same way buffered mode behaves).
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1264,7 +1264,9 @@ function setupDatadogGlobalTags(client, options) {
   if (!client.includeDataDogTags) {
     return;
   }
-  // DD_TAGS / DATADOG_TAGS: comma-delimited tags applied as global tags. Processed
+  // DD_TAGS / DATADOG_TAGS: comma- or whitespace-delimited tags applied as global
+  // tags. A value containing a comma is split on commas; otherwise whitespace is the
+  // separator, matching dd-trace-js and the Datadog Agent. Processed
   // before the DD_* mapping below so DD_ENV/DD_SERVICE/DD_VERSION win on conflict.
   // Skipped for child clients only: they already inherit DD_TAGS through the
   // parent's resolved globalTags, and re-applying would put the env tags on the
@@ -1275,7 +1277,9 @@ function setupDatadogGlobalTags(client, options) {
   if (!options.isChild) {
     const envTagsRaw = process.env.DD_TAGS || process.env.DATADOG_TAGS;
     if (envTagsRaw) {
-      const envTags = String(envTagsRaw).split(',').map(tag => tag.trim()).filter(tag => tag !== '');
+      const envTagsString = String(envTagsRaw);
+      const separator = envTagsString.includes(',') ? ',' : /\s+/;
+      const envTags = envTagsString.split(separator).map(tag => tag.trim()).filter(tag => tag !== '');
       if (envTags.length > 0) {
         client.globalTags = helpers.overrideTags(client.globalTags, envTags, options.telegraf);
       }

--- a/test/globalTags.js
+++ b/test/globalTags.js
@@ -408,6 +408,30 @@ describe('#DD_TAGS env var', () => {
     assert.deepStrictEqual(child.globalTags, ['env:prod']);
   });
 
+  it('should split DD_TAGS on whitespace when there are no commas', () => {
+    process.env.DD_TAGS = 'env:staging service:my-service version:abc123';
+    statsd = createHotShotsClient({ mock: true }, 'client');
+    assert.deepStrictEqual(statsd.globalTags, ['env:staging', 'service:my-service', 'version:abc123']);
+  });
+
+  it('should treat runs of any whitespace as a single DD_TAGS separator', () => {
+    process.env.DD_TAGS = ' rack:1 \t\n team:core  ';
+    statsd = createHotShotsClient({ mock: true }, 'client');
+    assert.deepStrictEqual(statsd.globalTags, ['rack:1', 'team:core']);
+  });
+
+  it('should keep whitespace inside DD_TAGS values when commas are present', () => {
+    process.env.DD_TAGS = 'rack:1,team:core team';
+    statsd = createHotShotsClient({ mock: true }, 'client');
+    assert.deepStrictEqual(statsd.globalTags, ['rack:1', 'team:core team']);
+  });
+
+  it('should split DATADOG_TAGS on whitespace when there are no commas', () => {
+    process.env.DATADOG_TAGS = 'legacy:tag rack:1';
+    statsd = createHotShotsClient({ mock: true }, 'client');
+    assert.deepStrictEqual(statsd.globalTags, ['legacy:tag', 'rack:1']);
+  });
+
   it('should prefer DD_TAGS over DATADOG_TAGS when both are set', () => {
     process.env.DD_TAGS = 'source:ddtags';
     process.env.DATADOG_TAGS = 'source:legacy';


### PR DESCRIPTION
Fixes #325

dd-trace-js and the Datadog Agent treat whitespace as the separator when the DD_TAGS value contains no comma, so hot-shots now does the same.
